### PR TITLE
Use Ionide.KeepAChangelog to populate package versions and release notes from CHANGELOG.md

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -23,7 +23,7 @@ let build = fun _ ->
   DotNet.build (fun p ->
      { p with
          Configuration = DotNet.BuildConfiguration.fromString configuration
-         MSBuildParams = MSBuild.CliArguments.Create() }) "LanguageServerProtocol.sln"
+         }) "LanguageServerProtocol.sln"
 
 
 let replaceFsLibLog = fun _ ->
@@ -44,7 +44,7 @@ let release = fun _ ->
        { p with
            OutputPath = Some (__SOURCE_DIRECTORY__ </> ".." </> releaseDir)
            Configuration = DotNet.BuildConfiguration.fromString configuration
-           MSBuildParams = MSBuild.CliArguments.Create () }) "src/Ionide.LanguageServerProtocol.fsproj"
+           }) "src/Ionide.LanguageServerProtocol.fsproj"
 
 let push = fun _ ->
     let key =

--- a/build/build.fs
+++ b/build/build.fs
@@ -7,62 +7,11 @@ open Fake.DotNet
 open Fake.Core.TargetOperators
 open System
 
-let changelogFilename = __SOURCE_DIRECTORY__ </> ".." </> "CHANGELOG.md"
-let changelog = Changelog.load changelogFilename
-let mutable latestEntry =
-    if Seq.isEmpty changelog.Entries
-    then Changelog.ChangelogEntry.New("0.0.1", "0.0.1-alpha.1", Some DateTime.Today, None, [], false)
-    else changelog.LatestEntry
-
 let configuration = Environment.environVarOrDefault "configuration" "Release"
 let project = "LanguageServerProtocol"
 let buildDir = "src" </> project </> "bin" </> "Debug"
 let buildReleaseDir = "src" </> project </>  "bin" </> "Release"
 let releaseDir = "release"
-
-let summary =
-    "Building Language Server Protocol server and clients in F#"
-
-let authors = "chethusk; Krzysztof-Cieslak;"
-let tags = "LSP; editor tooling"
-
-let gitOwner = "ionide"
-let gitName = "LanguageServerProtocol"
-let gitHome = "https://github.com/" + gitOwner
-let gitUrl = gitHome + "/" + gitName
-
-let packageReleaseNotes =
-    sprintf "%s/blob/v%s/CHANGELOG.md" gitUrl latestEntry.NuGetVersion
-
-// Helper function to remove blank lines
-let isEmptyChange =
-    function
-    | Changelog.Change.Added s
-    | Changelog.Change.Changed s
-    | Changelog.Change.Deprecated s
-    | Changelog.Change.Fixed s
-    | Changelog.Change.Removed s
-    | Changelog.Change.Security s
-    | Changelog.Change.Custom (_, s) -> String.isNullOrWhiteSpace s.CleanedText
-
-let releaseNotes =
-    latestEntry.Changes
-    |> List.filter (isEmptyChange >> not)
-    |> List.map (fun c -> " * " + c.ToString())
-    |> String.concat "\n"
-
-let properties =
-    [   ("Version", latestEntry.AssemblyVersion)
-        ("Authors", authors)
-        ("PackageProjectUrl", gitUrl)
-        ("PackageTags", tags)
-        ("RepositoryType", "git")
-        ("RepositoryUrl", gitUrl)
-        ("PackageLicenseExpression", "MIT")
-        ("PackageReleaseNotes", packageReleaseNotes)
-        ("PackageDescription", summary)
-        ("EnableSourceLink", "true") ]
-
 
 let clean = fun _ ->
   Shell.cleanDirs [ buildDir; buildReleaseDir; ]
@@ -74,7 +23,7 @@ let build = fun _ ->
   DotNet.build (fun p ->
      { p with
          Configuration = DotNet.BuildConfiguration.fromString configuration
-         MSBuildParams = { MSBuild.CliArguments.Create () with Properties = properties } }) "LanguageServerProtocol.sln"
+         MSBuildParams = MSBuild.CliArguments.Create() }) "LanguageServerProtocol.sln"
 
 
 let replaceFsLibLog = fun _ ->
@@ -95,7 +44,7 @@ let release = fun _ ->
        { p with
            OutputPath = Some (__SOURCE_DIRECTORY__ </> ".." </> releaseDir)
            Configuration = DotNet.BuildConfiguration.fromString configuration
-           MSBuildParams = { MSBuild.CliArguments.Create () with Properties = properties } }) "src/Ionide.LanguageServerProtocol.fsproj"
+           MSBuildParams = MSBuild.CliArguments.Create () }) "src/Ionide.LanguageServerProtocol.fsproj"
 
 let push = fun _ ->
     let key =

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,4 @@
 source https://api.nuget.org/v3/index.json
-source C:\\Users\\chethusk\pkg-temp
 
 storage: none
 framework: netstandard2.0

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,4 +1,5 @@
 source https://api.nuget.org/v3/index.json
+source C:\\Users\\chethusk\pkg-temp
 
 storage: none
 framework: netstandard2.0
@@ -6,6 +7,7 @@ framework: netstandard2.0
 nuget Newtonsoft.Json
 nuget FSharp.Core
 nuget Dotnet.ReproducibleBuilds copy_local:true
+nuget Ionide.KeepAChangelog.Tasks copy_local:true
 
 nuget Microsoft.NETFramework.ReferenceAssemblies
 github TheAngryByrd/FsLibLog:f81cba440bf0476bb4e2262b57a067a0d6ab78a7 src/FsLibLog/FsLibLog.fs

--- a/paket.lock
+++ b/paket.lock
@@ -24,6 +24,8 @@ NUGET
       Microsoft.Build.Tasks.Git (>= 1.1.1)
       Microsoft.SourceLink.Common (>= 1.1.1)
     Newtonsoft.Json (13.0.1)
+  remote: C:\\Users\\chethusk\pkg-temp
+    Ionide.KeepAChangelog.Tasks (1.0.0) - copy_local: true
 GITHUB
   remote: TheAngryByrd/FsLibLog
     src/FsLibLog/FsLibLog.fs (f81cba440bf0476bb4e2262b57a067a0d6ab78a7)

--- a/paket.lock
+++ b/paket.lock
@@ -8,6 +8,7 @@ NUGET
       Microsoft.SourceLink.GitHub (>= 1.0)
       Microsoft.SourceLink.GitLab (>= 1.0)
     FSharp.Core (6.0.1)
+    Ionide.KeepAChangelog.Tasks (0.1) - copy_local: true
     Microsoft.Build.Tasks.Git (1.1.1) - copy_local: true
     Microsoft.NETFramework.ReferenceAssemblies (1.0.2)
     Microsoft.SourceLink.AzureRepos.Git (1.1.1) - copy_local: true
@@ -24,8 +25,6 @@ NUGET
       Microsoft.Build.Tasks.Git (>= 1.1.1)
       Microsoft.SourceLink.Common (>= 1.1.1)
     Newtonsoft.Json (13.0.1)
-  remote: C:\\Users\\chethusk\pkg-temp
-    Ionide.KeepAChangelog.Tasks (1.0.0) - copy_local: true
 GITHUB
   remote: TheAngryByrd/FsLibLog
     src/FsLibLog/FsLibLog.fs (f81cba440bf0476bb4e2262b57a067a0d6ab78a7)

--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -5,9 +5,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ChangelogFile>$(MSBuildThisFileDirectory)../CHANGELOG.md</ChangelogFile>
     <Description>Library for implementing Language Server Protocol in F#.</Description>
-    <PackageTags>LSP</PackageTags>
+    <PackageTags>LSP, editor tooling</PackageTags>
+    <Authors>chethusk; Krzysztof-Cieslak</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/ionide/LanguageServerProtocol</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\paket-files\TheAngryByrd\FsLibLog\src\FsLibLog\FsLibLog.fs">

--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -3,6 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ChangelogFile>$(MSBuildThisFileDirectory)../CHANGELOG.md</ChangelogFile>
+    <Description>Library for implementing Language Server Protocol in F#.</Description>
+    <PackageTags>LSP</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\paket-files\TheAngryByrd\FsLibLog\src\FsLibLog\FsLibLog.fs">
@@ -10,6 +15,7 @@
       <Link>paket-files/FsLibLog.fs</Link>
     </Compile>
     <Compile Include="LanguageServerProtocol.fs" />
+    <None Include="../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/paket.references
+++ b/src/paket.references
@@ -1,6 +1,7 @@
 Newtonsoft.Json
 FSharp.Core
 Dotnet.ReproducibleBuilds
+Ionide.KeepAChangelog.Tasks
 
 Microsoft.NETFramework.ReferenceAssemblies
 File: FsLibLog.fs


### PR DESCRIPTION
This uses the new [Ionide.KeepAChangelog.Tasks](https://github.com/ionide/KeepAChangelog) package to populate nuget package metadata from the changelog. This means a lot of property manipulation can come out of the FAKE script so that pipelines are more simple, and help ensure that 'simple' command line builds are kept in sync with the 'full' build from FAKE.

With this, the act of changing the CHANGELOG is all that's required to bump the package version.