### PR TITLE
Fix Server.start/defaultHandlings incompatibility

### DIFF
--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -2875,7 +2875,7 @@ module Server =
         | ErrorExitWithoutShutdown = 1
         | ErrorStreamClosed = 2
 
-    let startWithSetup<'a when 'a :> LspClient> (setupRequestHandlings : 'a -> Map<string,Delegate>) (input: Stream) (output: Stream) (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'a) =
+    let startWithSetup<'client when 'client :> LspClient> (setupRequestHandlings : 'client -> Map<string,Delegate>) (input: Stream) (output: Stream) (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client) =
 
         use jsonRpcHandler = new HeaderDelimitedMessageHandler(output, input, jsonRpcFormatter)
         use jsonRpc = new JsonRpc(jsonRpcHandler)
@@ -2989,9 +2989,13 @@ module Server =
         ]
         |> Map.ofList
 
-    let start<'a, 'b when 'a :> LspClient and 'b :> LspServer> (requestHandlings : Map<string,Delegate>) (input: Stream) (output: Stream) (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'a) (serverCreator: 'a -> 'b) =
-        let requestHandlingSetup _ = requestHandlings
-        startWithSetup requestHandlingSetup
+    let start<'client, 'server when 'client :> LspClient and 'server :> LspServer> (requestHandlings : Map<string, ServerRequestHandling<'server>>) (input: Stream) (output: Stream) (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client) (serverCreator: 'client -> 'server) =
+        let requestHandlingSetup client =
+            let server = serverCreator client
+            requestHandlings
+            |> Map.map (fun _ requestHandling -> requestHandling.Run server)
+
+        startWithSetup requestHandlingSetup input output clientCreator
 
 module Client =
     open System


### PR DESCRIPTION
Since the switch to StreamingJsonRpc, `Server.start` and `defaultHandlings` got out of sync.
This change seem to fix things in a sense that I can still do
```f#
Server.start (Server.defaultRequestHandlings ()) input output [myclient] (fun client -> [myserver])
```
as it was in 0.3.1.