### PR TITLE
Split files into logical chunks

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "paket"
       ]
+    },
+    "fantomas-tool": {
+      "version": "4.7.8",
+      "commands": [
+        "fantomas"
+      ]
     }
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+max_line_length=120
+fsharp_max_if_then_else_short_width=60
+fsharp_max_infix_operator_expression=60
+fsharp_max_record_width=80
+fsharp_max_array_or_list_width=80
+fsharp_max_value_binding_width=120
+fsharp_max_function_binding_width=120
+fsharp_max_dot_get_expression_width=120

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/src/Client.fs
+++ b/src/Client.fs
@@ -1,0 +1,110 @@
+namespace Ionide.LanguageServerProtocol
+
+open Ionide.LanguageServerProtocol.Types
+
+module private ClientUtil =
+  /// Return the JSON-RPC "not implemented" error
+  let notImplemented<'t> = async.Return LspResult.notImplemented<'t>
+
+  /// Do nothing and ignore the notification
+  let ignoreNotification = async.Return(())
+
+open ClientUtil
+
+[<AbstractClass>]
+type LspClient() =
+
+  /// The show message notification is sent from a server to a client to ask the client to display
+  /// a particular message in the user interface.
+  abstract member WindowShowMessage: ShowMessageParams -> Async<unit>
+
+  default __.WindowShowMessage(_) = ignoreNotification
+
+  /// The show message request is sent from a server to a client to ask the client to display
+  /// a particular message in the user interface. In addition to the show message notification the
+  /// request allows to pass actions and to wait for an answer from the client.
+  abstract member WindowShowMessageRequest: ShowMessageRequestParams -> AsyncLspResult<MessageActionItem option>
+
+  default __.WindowShowMessageRequest(_) = notImplemented
+
+  /// The log message notification is sent from the server to the client to ask the client to log
+  ///a particular message.
+  abstract member WindowLogMessage: LogMessageParams -> Async<unit>
+
+  default __.WindowLogMessage(_) = ignoreNotification
+
+  /// The telemetry notification is sent from the server to the client to ask the client to log
+  /// a telemetry event.
+  abstract member TelemetryEvent: Newtonsoft.Json.Linq.JToken -> Async<unit>
+
+  default __.TelemetryEvent(_) = ignoreNotification
+
+  /// The `client/registerCapability` request is sent from the server to the client to register for a new
+  /// capability on the client side. Not all clients need to support dynamic capability registration.
+  /// A client opts in via the dynamicRegistration property on the specific client capabilities. A client
+  /// can even provide dynamic registration for capability A but not for capability B.
+  abstract member ClientRegisterCapability: RegistrationParams -> AsyncLspResult<unit>
+
+  default __.ClientRegisterCapability(_) = notImplemented
+
+  /// The `client/unregisterCapability` request is sent from the server to the client to unregister a previously
+  /// registered capability.
+  abstract member ClientUnregisterCapability: UnregistrationParams -> AsyncLspResult<unit>
+
+  default __.ClientUnregisterCapability(_) = notImplemented
+
+  /// Many tools support more than one root folder per workspace. Examples for this are VS Code’s multi-root
+  /// support, Atom’s project folder support or Sublime’s project support. If a client workspace consists of
+  /// multiple roots then a server typically needs to know about this. The protocol up to know assumes one root
+  /// folder which is announce to the server by the rootUri property of the InitializeParams.
+  /// If the client supports workspace folders and announces them via the corresponding workspaceFolders client
+  /// capability the InitializeParams contain an additional property workspaceFolders with the configured
+  /// workspace folders when the server starts.
+  ///
+  /// The workspace/workspaceFolders request is sent from the server to the client to fetch the current open
+  /// list of workspace folders. Returns null in the response if only a single file is open in the tool.
+  /// Returns an empty array if a workspace is open but no folders are configured.
+  abstract member WorkspaceWorkspaceFolders: unit -> AsyncLspResult<WorkspaceFolder [] option>
+
+  default __.WorkspaceWorkspaceFolders() = notImplemented
+
+  /// The workspace/configuration request is sent from the server to the client to fetch configuration
+  /// settings from the client.
+  ///
+  /// The request can fetch n configuration settings in one roundtrip. The order of the returned configuration
+  /// settings correspond to the order of the passed ConfigurationItems (e.g. the first item in the response
+  /// is the result for the first configuration item in the params).
+  abstract member WorkspaceConfiguration: ConfigurationParams -> AsyncLspResult<Newtonsoft.Json.Linq.JToken []>
+
+  default __.WorkspaceConfiguration(_) = notImplemented
+
+  abstract member WorkspaceApplyEdit: ApplyWorkspaceEditParams -> AsyncLspResult<ApplyWorkspaceEditResponse>
+  default __.WorkspaceApplyEdit(_) = notImplemented
+
+  /// The workspace/semanticTokens/refresh request is sent from the server to the client.
+  /// Servers can use it to ask clients to refresh the editors for which this server provides semantic tokens.
+  /// As a result the client should ask the server to recompute the semantic tokens for these editors.
+  /// This is useful if a server detects a project wide configuration change which requires a re-calculation
+  /// of all semantic tokens. Note that the client still has the freedom to delay the re-calculation of
+  /// the semantic tokens if for example an editor is currently not visible.
+  abstract member WorkspaceSemanticTokensRefresh: unit -> Async<unit>
+
+  default __.WorkspaceSemanticTokensRefresh() = ignoreNotification
+
+  /// Diagnostics notification are sent from the server to the client to signal results of validation runs.
+  ///
+  /// Diagnostics are “owned” by the server so it is the server’s responsibility to clear them if necessary.
+  /// The following rule is used for VS Code servers that generate diagnostics:
+  ///
+  /// * if a language is single file only (for example HTML) then diagnostics are cleared by the server when
+  ///   the file is closed.
+  /// * if a language has a project system (for example C#) diagnostics are not cleared when a file closes.
+  ///   When a project is opened all diagnostics for all files are recomputed (or read from a cache).
+  ///
+  /// When a file changes it is the server’s responsibility to re-compute diagnostics and push them to the
+  /// client. If the computed set is empty it has to push the empty array to clear former diagnostics.
+  /// Newly pushed diagnostics always replace previously pushed diagnostics. There is no merging that happens
+  /// on the client side.
+  abstract member TextDocumentPublishDiagnostics: PublishDiagnosticsParams -> Async<unit>
+
+  default __.TextDocumentPublishDiagnostics(_) = ignoreNotification

--- a/src/FsLibLog.fs
+++ b/src/FsLibLog.fs
@@ -1,12 +1,13 @@
 // this is from https://github.com/TheAngryByrd/FsLibLog/blob/f81cba440bf0476bb4e2262b57a067a0d6ab78a7/src/FsLibLog/FsLibLog.fs
 
-namespace LanguageServerProtocol.Logging
+namespace Ionide.LanguageServerProtocol.Logging
 
 
 [<AutoOpen>]
 module Types =
-    open System
-    type LogLevel =
+  open System
+
+  type LogLevel =
     | Trace = 0
     | Debug = 1
     | Info = 2
@@ -14,778 +15,750 @@ module Types =
     | Error = 4
     | Fatal = 5
 
-    /// An optional message thunk.
+  /// An optional message thunk.
+  ///
+  /// - If `None` is provided, this typically signals to the logger to do a isEnabled check.
+  /// - If `Some` is provided, this signals the logger to log.
+  type MessageThunk = (unit -> string) option
+
+  /// The signature of a log message function
+  type Logger = LogLevel -> MessageThunk -> exn option -> obj array -> bool
+  type MappedContext = string -> obj -> bool -> IDisposable
+
+  /// Type representing a Log
+  type Log =
+    { LogLevel: LogLevel
+      Message: MessageThunk
+      Exception: exn option
+      Parameters: obj list
+      AdditionalNamedParameters: ((string * obj * bool) list) }
+    static member StartLogLevel(logLevel: LogLevel) =
+      { LogLevel = logLevel
+        Message = None
+        Exception = None
+        Parameters = List.empty
+        AdditionalNamedParameters = List.empty }
+
+  /// An interface wrapper for `Logger`. Useful when using depedency injection frameworks.
+  type ILog =
+    abstract member Log: Logger
+    abstract member MappedContext: MappedContext
+
+  [<AutoOpen>]
+  module Inner =
+    open System.Collections.Generic
+
+    type DisposableStack() =
+      let stack = Stack<IDisposable>()
+
+      interface IDisposable with
+        member __.Dispose() =
+          while stack.Count > 0 do
+            stack.Pop().Dispose()
+
+      member __.Push(item: IDisposable) = stack.Push item
+      member __.Push(items: IDisposable list) = items |> List.iter stack.Push
+
+      static member Create(items: IDisposable list) =
+        let ds = new DisposableStack()
+        ds.Push items
+        ds
+
+    type ILog with
+
+      /// **Description**
+      ///
+      /// Logs a log
+      ///
+      /// **Parameters**
+      ///   * `log` - parameter of type `Log`
+      ///
+      /// **Output Type**
+      ///   * `bool`
+      member logger.fromLog(log: Log) =
+        use __ =
+          log.AdditionalNamedParameters
+          |> List.map (fun (key, value, destructure) -> logger.MappedContext key value destructure)
+          // This stack is important, it causes us to unwind as if you have multiple uses in a row
+          |> DisposableStack.Create
+
+        log.Parameters
+        |> List.toArray
+        |> logger.Log log.LogLevel log.Message log.Exception
+
+      /// **Description**
+      ///
+      /// Logs a fatal log message given a log configurer.  Lets caller know if log was sent with boolean return.
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `bool`
+      member logger.fatal'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Fatal
+        |> logConfig
+        |> logger.fromLog
+
+      /// **Description**
+      ///
+      /// Logs a fatal log message given a log configurer
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `unit`
+      member logger.fatal(logConfig: Log -> Log) = logger.fatal' logConfig |> ignore
+
+      /// **Description**
+      ///
+      /// Logs a error log message given a log configurer.  Lets caller know if log was sent with boolean return.
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `bool`
+      member logger.error'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Error
+        |> logConfig
+        |> logger.fromLog
+
+      /// **Description**
+      ///
+      /// Logs an error log message given a log configurer
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `unit`
+      member logger.error(logConfig: Log -> Log) = logger.error' logConfig |> ignore
+
+      /// **Description**
+      ///
+      /// Logs a warn log message given a log configurer.  Lets caller know if log was sent with boolean return.
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `bool`
+      member logger.warn'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Warn
+        |> logConfig
+        |> logger.fromLog
+
+      /// **Description**
+      ///
+      /// Logs a warn log message given a log configurer
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `unit`
+      member logger.warn(logConfig: Log -> Log) = logger.warn' logConfig |> ignore
+
+      /// **Description**
+      ///
+      /// Logs a info log message given a log configurer.  Lets caller know if log was sent with boolean return.
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `bool`
+      member logger.info'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Info
+        |> logConfig
+        |> logger.fromLog
+
+      /// **Description**
+      ///
+      /// Logs a info log message given a log configurer
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `unit`
+      member logger.info(logConfig: Log -> Log) = logger.info' logConfig |> ignore
+
+      /// **Description**
+      ///
+      /// Logs a debug log message given a log configurer.  Lets caller know if log was sent with boolean return.
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `bool`
+      member logger.debug'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Debug
+        |> logConfig
+        |> logger.fromLog
+
+      /// **Description**
+      ///
+      /// Logs a debug log message given a log configurer
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `unit`
+      member logger.debug(logConfig: Log -> Log) = logger.debug' logConfig |> ignore
+
+      /// **Description**
+      ///
+      /// Logs a trace log message given a log configurer.  Lets caller know if log was sent with boolean return.
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `bool`
+      member logger.trace'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Trace
+        |> logConfig
+        |> logger.fromLog
+
+      /// **Description**
+      ///
+      /// Logs a trace log message given a log configurer
+      ///
+      /// **Parameters**
+      ///   * `logConfig` - parameter of type `Log -> Log`
+      ///
+      /// **Output Type**
+      ///   * `unit`
+      member logger.trace(logConfig: Log -> Log) = logger.trace' logConfig |> ignore
+
+
+  /// An interface for retrieving a concrete logger such as Serilog, Nlog, etc.
+  type ILogProvider =
+    abstract member GetLogger: string -> Logger
+    abstract member OpenNestedContext: string -> IDisposable
+    abstract member OpenMappedContext: string -> obj -> bool -> IDisposable
+
+  module Log =
+
+    /// **Description**
     ///
-    /// - If `None` is provided, this typically signals to the logger to do a isEnabled check.
-    /// - If `Some` is provided, this signals the logger to log.
-    type MessageThunk = (unit -> string) option
+    /// Amends a `Log` with a message
+    ///
+    /// **Parameters**
+    ///   * `message` - parameter of type `string`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    let setMessage (message: string) (log: Log) = { log with Message = Some(fun () -> message) }
 
-    /// The signature of a log message function
-    type Logger = LogLevel -> MessageThunk -> exn option -> obj array -> bool
-    type MappedContext = string -> obj -> bool -> IDisposable
+    /// **Description**
+    ///
+    /// Amends a `Log` with a message thunk.  Useful for "expensive" string construction scenarios.
+    ///
+    /// **Parameters**
+    ///   * `messageThunk` - parameter of type `unit -> string`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    ///
+    /// **Exceptions**
+    ///
+    let setMessageThunk (messageThunk: unit -> string) (log: Log) = { log with Message = Some messageThunk }
 
-    /// Type representing a Log
-    type Log = {
-        LogLevel : LogLevel
-        Message : MessageThunk
-        Exception : exn option
-        Parameters : obj list
-        AdditionalNamedParameters : ((string*obj*bool) list)
-    }
-        with
-            static member StartLogLevel (logLevel : LogLevel) =
-                {
-                    LogLevel = logLevel
-                    Message = None
-                    Exception = None
-                    Parameters = List.empty
-                    AdditionalNamedParameters = List.empty
-                }
+    /// **Description**
+    ///
+    /// Amends a `Log` with a parameter.
+    ///
+    /// **Parameters**
+    ///   * `param` - parameter of type `'a`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    ///
+    /// **Exceptions**
+    ///
+    let addParameter (param: 'a) (log: Log) = { log with Parameters = List.append log.Parameters [ (box param) ] }
 
-    /// An interface wrapper for `Logger`. Useful when using depedency injection frameworks.
-    type ILog =
-        abstract member Log :  Logger
-        abstract member MappedContext :  MappedContext
-
-    [<AutoOpen>]
-    module Inner =
-        open System.Collections.Generic
-
-        type DisposableStack() =
-            let stack = Stack<IDisposable>()
-
-            interface IDisposable with
-                member __.Dispose () =
-                    while stack.Count > 0 do
-                        stack.Pop().Dispose()
-
-            member __.Push (item : IDisposable) = stack.Push item
-            member __.Push (items : IDisposable list) = items |> List.iter stack.Push
-
-            static member Create (items : IDisposable list) =
-                let ds = new DisposableStack()
-                ds.Push items
-                ds
-
-        type ILog with
-
-            /// **Description**
-            ///
-            /// Logs a log
-            ///
-            /// **Parameters**
-            ///   * `log` - parameter of type `Log`
-            ///
-            /// **Output Type**
-            ///   * `bool`
-            member logger.fromLog (log : Log) =
-                use __ =
-                    log.AdditionalNamedParameters
-                    |> List.map(fun (key,value, destructure) -> logger.MappedContext key value destructure)
-                    // This stack is important, it causes us to unwind as if you have multiple uses in a row
-                    |> DisposableStack.Create
-
-                log.Parameters
-                |> List.toArray
-                |> logger.Log log.LogLevel log.Message log.Exception
-
-            /// **Description**
-            ///
-            /// Logs a fatal log message given a log configurer.  Lets caller know if log was sent with boolean return.
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `bool`
-            member logger.fatal' (logConfig : Log -> Log) =
-                Log.StartLogLevel LogLevel.Fatal
-                |> logConfig
-                |> logger.fromLog
-
-            /// **Description**
-            ///
-            /// Logs a fatal log message given a log configurer
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `unit`
-            member logger.fatal (logConfig : Log -> Log) =
-                logger.fatal' logConfig |> ignore
-
-            /// **Description**
-            ///
-            /// Logs a error log message given a log configurer.  Lets caller know if log was sent with boolean return.
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `bool`
-            member logger.error' (logConfig : Log -> Log) =
-                Log.StartLogLevel LogLevel.Error
-                |> logConfig
-                |> logger.fromLog
-
-            /// **Description**
-            ///
-            /// Logs an error log message given a log configurer
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `unit`
-            member logger.error (logConfig : Log -> Log) =
-                logger.error' logConfig |> ignore
-
-            /// **Description**
-            ///
-            /// Logs a warn log message given a log configurer.  Lets caller know if log was sent with boolean return.
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `bool`
-            member logger.warn' (logConfig : Log -> Log) =
-                Log.StartLogLevel LogLevel.Warn
-                |> logConfig
-                |> logger.fromLog
-
-            /// **Description**
-            ///
-            /// Logs a warn log message given a log configurer
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `unit`
-            member logger.warn (logConfig : Log -> Log) =
-                logger.warn' logConfig |> ignore
-
-            /// **Description**
-            ///
-            /// Logs a info log message given a log configurer.  Lets caller know if log was sent with boolean return.
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `bool`
-            member logger.info' (logConfig : Log -> Log) =
-                Log.StartLogLevel LogLevel.Info
-                |> logConfig
-                |> logger.fromLog
-
-            /// **Description**
-            ///
-            /// Logs a info log message given a log configurer
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `unit`
-            member logger.info (logConfig : Log -> Log) =
-                logger.info' logConfig |> ignore
-
-            /// **Description**
-            ///
-            /// Logs a debug log message given a log configurer.  Lets caller know if log was sent with boolean return.
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `bool`
-            member logger.debug' (logConfig : Log -> Log) =
-                Log.StartLogLevel LogLevel.Debug
-                |> logConfig
-                |> logger.fromLog
-
-            /// **Description**
-            ///
-            /// Logs a debug log message given a log configurer
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `unit`
-            member logger.debug (logConfig : Log -> Log) =
-                logger.debug' logConfig |> ignore
-
-            /// **Description**
-            ///
-            /// Logs a trace log message given a log configurer.  Lets caller know if log was sent with boolean return.
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `bool`
-            member logger.trace' (logConfig : Log -> Log) =
-                Log.StartLogLevel LogLevel.Trace
-                |> logConfig
-                |> logger.fromLog
-
-            /// **Description**
-            ///
-            /// Logs a trace log message given a log configurer
-            ///
-            /// **Parameters**
-            ///   * `logConfig` - parameter of type `Log -> Log`
-            ///
-            /// **Output Type**
-            ///   * `unit`
-            member logger.trace (logConfig : Log -> Log) =
-                logger.trace' logConfig |> ignore
-
-
-    /// An interface for retrieving a concrete logger such as Serilog, Nlog, etc.
-    type ILogProvider =
-        abstract member GetLogger : string -> Logger
-        abstract member OpenNestedContext : string -> IDisposable
-        abstract member OpenMappedContext : string -> obj -> bool -> IDisposable
-
-    module Log =
-
-        /// **Description**
-        ///
-        /// Amends a `Log` with a message
-        ///
-        /// **Parameters**
-        ///   * `message` - parameter of type `string`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        let setMessage (message : string) (log : Log) =
-            { log with Message = Some (fun () -> message) }
-
-        /// **Description**
-        ///
-        /// Amends a `Log` with a message thunk.  Useful for "expensive" string construction scenarios.
-        ///
-        /// **Parameters**
-        ///   * `messageThunk` - parameter of type `unit -> string`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        ///
-        /// **Exceptions**
-        ///
-        let setMessageThunk (messageThunk : unit -> string) (log : Log) =
-            { log with Message = Some messageThunk }
-
-        /// **Description**
-        ///
-        /// Amends a `Log` with a parameter.
-        ///
-        /// **Parameters**
-        ///   * `param` - parameter of type `'a`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        ///
-        /// **Exceptions**
-        ///
-        let addParameter (param : 'a) (log : Log) =
-            { log with Parameters = List.append log.Parameters [(box param)] }
-
-        /// **Description**
-        ///
-        /// Amends a `Log` with a list of parameters.
-        ///
-        /// **Parameters**
-        ///   * `params` - parameter of type `obj list`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        ///
-        /// **Exceptions**
-        ///
-        let addParameters (``params`` : obj list) (log : Log) =
-            let ``params`` =
-                ``params``
-                |> List.map box
-            { log with Parameters = log.Parameters @ ``params`` }
+    /// **Description**
+    ///
+    /// Amends a `Log` with a list of parameters.
+    ///
+    /// **Parameters**
+    ///   * `params` - parameter of type `obj list`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    ///
+    /// **Exceptions**
+    ///
+    let addParameters (``params``: obj list) (log: Log) =
+      let ``params`` = ``params`` |> List.map box
+      { log with Parameters = log.Parameters @ ``params`` }
 
 
 
-        /// **Description**
-        ///
-        /// Amends a `Log` with additional named parameters for context. This helper adds more context to a log.
-        /// This DOES NOT affect the parameters set for a message template.
-        /// This is the same calling OpenMappedContext right before logging.
-        ///
-        /// **Parameters**
-        ///   * `key` - parameter of type `string`
-        ///   * `value` - parameter of type `obj`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        ///
-        /// **Exceptions**
-        ///
-        let addContext (key : string) (value : obj) (log : Log) =
-            { log with AdditionalNamedParameters = List.append log.AdditionalNamedParameters [key, (box value), false] }
+    /// **Description**
+    ///
+    /// Amends a `Log` with additional named parameters for context. This helper adds more context to a log.
+    /// This DOES NOT affect the parameters set for a message template.
+    /// This is the same calling OpenMappedContext right before logging.
+    ///
+    /// **Parameters**
+    ///   * `key` - parameter of type `string`
+    ///   * `value` - parameter of type `obj`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    ///
+    /// **Exceptions**
+    ///
+    let addContext (key: string) (value: obj) (log: Log) =
+      { log with AdditionalNamedParameters = List.append log.AdditionalNamedParameters [ key, (box value), false ] }
 
 
-        /// **Description**
-        ///
-        /// Amends a `Log` with additional named parameters for context. This helper adds more context to a log.
-        /// This DOES NOT affect the parameters set for a message template.
-        /// This is the same calling OpenMappedContext right before logging.
-        /// This destructures an object rather than calling `ToString()` on it.
-        /// WARNING: Destructring can be expensive.
-        ///
-        /// **Parameters**
-        ///   * `key` - parameter of type `string`
-        ///   * `value` - parameter of type `obj`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        ///
-        /// **Exceptions**
-        ///
-        let addContextDestructured (key : string) (value : obj) (log : Log) =
-            { log with AdditionalNamedParameters = List.append log.AdditionalNamedParameters [key, (box value),true] }
+    /// **Description**
+    ///
+    /// Amends a `Log` with additional named parameters for context. This helper adds more context to a log.
+    /// This DOES NOT affect the parameters set for a message template.
+    /// This is the same calling OpenMappedContext right before logging.
+    /// This destructures an object rather than calling `ToString()` on it.
+    /// WARNING: Destructring can be expensive.
+    ///
+    /// **Parameters**
+    ///   * `key` - parameter of type `string`
+    ///   * `value` - parameter of type `obj`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    ///
+    /// **Exceptions**
+    ///
+    let addContextDestructured (key: string) (value: obj) (log: Log) =
+      { log with AdditionalNamedParameters = List.append log.AdditionalNamedParameters [ key, (box value), true ] }
 
 
-        /// **Description**
-        ///
-        /// Amends a `Log` with an `exn`. Handles nulls.
-        ///
-        /// **Parameters**
-        ///   * `exception` - parameter of type `exn`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        ///
-        /// **Exceptions**
-        ///
-        let addException (``exception`` : exn) (log : Log) =
-            { log with Exception = Option.ofObj ``exception``}
+    /// **Description**
+    ///
+    /// Amends a `Log` with an `exn`. Handles nulls.
+    ///
+    /// **Parameters**
+    ///   * `exception` - parameter of type `exn`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    ///
+    /// **Exceptions**
+    ///
+    let addException (``exception``: exn) (log: Log) = { log with Exception = Option.ofObj ``exception`` }
 
-        /// **Description**
-        ///
-        /// Amends a `Log` with an `exn`.  Handles nulls.
-        ///
-        /// **Parameters**
-        ///   * `exception` - parameter of type `exn`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        ///
-        /// **Exceptions**
-        ///
-        let addExn (``exception`` : exn) (log : Log) =
-            addException ``exception`` log
+    /// **Description**
+    ///
+    /// Amends a `Log` with an `exn`.  Handles nulls.
+    ///
+    /// **Parameters**
+    ///   * `exception` - parameter of type `exn`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    ///
+    /// **Exceptions**
+    ///
+    let addExn (``exception``: exn) (log: Log) = addException ``exception`` log
 
-        /// **Description**
-        ///
-        /// Amends a `Log` with a given `LogLevel`
-        ///
-        /// **Parameters**
-        ///   * `logLevel` - parameter of type `LogLevel`
-        ///   * `log` - parameter of type `Log`
-        ///
-        /// **Output Type**
-        ///   * `Log`
-        ///
-        /// **Exceptions**
-        ///
-        let setLogLevel (logLevel : LogLevel) (log : Log) =
-            { log with LogLevel = logLevel}
+    /// **Description**
+    ///
+    /// Amends a `Log` with a given `LogLevel`
+    ///
+    /// **Parameters**
+    ///   * `logLevel` - parameter of type `LogLevel`
+    ///   * `log` - parameter of type `Log`
+    ///
+    /// **Output Type**
+    ///   * `Log`
+    ///
+    /// **Exceptions**
+    ///
+    let setLogLevel (logLevel: LogLevel) (log: Log) = { log with LogLevel = logLevel }
+
 module Providers =
-    module SerilogProvider =
-        open System
-        open System.Linq.Expressions
+  module SerilogProvider =
+    open System
+    open System.Linq.Expressions
 
-        let getLogManagerType () =
-            Type.GetType("Serilog.Log, Serilog")
-        let isAvailable () =
-            getLogManagerType () |> isNull |> not
+    let getLogManagerType () = Type.GetType("Serilog.Log, Serilog")
+    let isAvailable () = getLogManagerType () |> isNull |> not
 
-        let getPushProperty () =
+    let getPushProperty () =
 
-            let ndcContextType =
-                Type.GetType("Serilog.Context.LogContext, Serilog")
-                |> Option.ofObj
-                |> Option.defaultWith (fun () -> Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx"))
+      let ndcContextType =
+        Type.GetType("Serilog.Context.LogContext, Serilog")
+        |> Option.ofObj
+        |> Option.defaultWith (fun () -> Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx"))
 
-            ()
-            let pushPropertyMethod =
-                ndcContextType.GetMethod( "PushProperty",
-                    [|typedefof<string>; typedefof<obj>; typedefof<bool>|])
+      ()
 
-            let nameParam = Expression.Parameter(typedefof<string>, "name")
-            let valueParam = Expression.Parameter(typedefof<obj>, "value")
-            let destructureObjectParam = Expression.Parameter(typedefof<bool>, "destructureObjects");
-            let pushPropertyMethodCall =
-                Expression.Call(null, pushPropertyMethod, nameParam, valueParam, destructureObjectParam);
-            let pushProperty =
-                Expression
-                    .Lambda<Func<string, obj, bool, IDisposable>>(
-                        pushPropertyMethodCall,
-                        nameParam,
-                        valueParam,
-                        destructureObjectParam)
-                    .Compile();
+      let pushPropertyMethod =
+        ndcContextType.GetMethod("PushProperty", [| typedefof<string>; typedefof<obj>; typedefof<bool> |])
 
-            fun key value destructure -> pushProperty.Invoke(key, value, destructure)
+      let nameParam = Expression.Parameter(typedefof<string>, "name")
+      let valueParam = Expression.Parameter(typedefof<obj>, "value")
+      let destructureObjectParam = Expression.Parameter(typedefof<bool>, "destructureObjects")
 
+      let pushPropertyMethodCall =
+        Expression.Call(null, pushPropertyMethod, nameParam, valueParam, destructureObjectParam)
 
-        let getForContextMethodCall () =
-            let logManagerType = getLogManagerType ()
-            let method = logManagerType.GetMethod("ForContext", [|typedefof<string>; typedefof<obj>; typedefof<bool>|])
-            let propertyNameParam = Expression.Parameter(typedefof<string>, "propertyName")
-            let valueParam = Expression.Parameter(typedefof<obj>, "value")
-            let destructureObjectsParam = Expression.Parameter(typedefof<bool>, "destructureObjects")
-            let exrs : Expression []=
-                [|
-                    propertyNameParam
-                    valueParam
-                    destructureObjectsParam
-                |]
-            let methodCall =
-                Expression.Call(null, method, exrs)
-            let func =
-                Expression.Lambda<Func<string, obj, bool, obj>>(
-                    methodCall,
-                    propertyNameParam,
-                    valueParam,
-                    destructureObjectsParam).Compile()
-            fun name -> func.Invoke("SourceContext", name, false)
+      let pushProperty =
+        Expression
+          .Lambda<Func<string, obj, bool, IDisposable>>(
+            pushPropertyMethodCall,
+            nameParam,
+            valueParam,
+            destructureObjectParam
+          )
+          .Compile()
 
-        type SerilogGateway = {
-            Write : obj -> obj -> string -> obj [] -> unit
-            WriteException : obj -> obj -> exn -> string -> obj [] -> unit
-            IsEnabled : obj -> obj -> bool
-            TranslateLevel : LogLevel -> obj
-        } with
-            static member Create () =
-                let logEventLevelType = Type.GetType("Serilog.Events.LogEventLevel, Serilog")
-                if (logEventLevelType |> isNull) then
-                    failwith ("Type Serilog.Events.LogEventLevel was not found.")
-
-                let debugLevel = Enum.Parse(logEventLevelType, "Debug", false)
-                let errorLevel = Enum.Parse(logEventLevelType, "Error", false)
-                let fatalLevel = Enum.Parse(logEventLevelType, "Fatal", false)
-                let informationLevel = Enum.Parse(logEventLevelType, "Information", false)
-                let verboseLevel = Enum.Parse(logEventLevelType, "Verbose", false)
-                let warningLevel = Enum.Parse(logEventLevelType, "Warning", false)
-                let translateLevel (level : LogLevel) =
-                    match level with
-                    | LogLevel.Fatal -> fatalLevel
-                    | LogLevel.Error -> errorLevel
-                    | LogLevel.Warn -> warningLevel
-                    | LogLevel.Info -> informationLevel
-                    | LogLevel.Debug -> debugLevel
-                    | LogLevel.Trace -> verboseLevel
-                    | _ -> debugLevel
-
-                let loggerType = Type.GetType("Serilog.ILogger, Serilog")
-                if (loggerType |> isNull) then failwith ("Type Serilog.ILogger was not found.")
-                let isEnabledMethodInfo = loggerType.GetMethod("IsEnabled", [|logEventLevelType|])
-                let instanceParam = Expression.Parameter(typedefof<obj>)
-                let instanceCast = Expression.Convert(instanceParam, loggerType)
-                let levelParam = Expression.Parameter(typedefof<obj>)
-                let levelCast = Expression.Convert(levelParam, logEventLevelType)
-                let isEnabledMethodCall = Expression.Call(instanceCast, isEnabledMethodInfo, levelCast)
-                let isEnabled =
-                    Expression
-                        .Lambda<Func<obj, obj, bool>>(isEnabledMethodCall, instanceParam, levelParam).Compile()
-
-                let writeMethodInfo =
-                    loggerType.GetMethod("Write", [|logEventLevelType; typedefof<string>; typedefof<obj []>|])
-                let messageParam = Expression.Parameter(typedefof<string>)
-                let propertyValuesParam = Expression.Parameter(typedefof<obj []>)
-                let writeMethodExp =
-                    Expression.Call(
-                        instanceCast,
-                        writeMethodInfo,
-                        levelCast,
-                        messageParam,
-                        propertyValuesParam)
-                let expression =
-                    Expression.Lambda<Action<obj, obj, string, obj []>>(
-                        writeMethodExp,
-                        instanceParam,
-                        levelParam,
-                        messageParam,
-                        propertyValuesParam)
-                let write = expression.Compile()
-
-                let writeExceptionMethodInfo =
-                    loggerType.GetMethod(
-                        "Write",
-                        [| logEventLevelType; typedefof<exn>; typedefof<string>; typedefof<obj []>|])
-                let exceptionParam = Expression.Parameter(typedefof<exn>)
-                let writeMethodExp =
-                    Expression.Call(
-                        instanceCast,
-                        writeExceptionMethodInfo,
-                        levelCast,
-                        exceptionParam,
-                        messageParam,
-                        propertyValuesParam)
-                let writeException =
-                    Expression.Lambda<Action<obj, obj, exn, string, obj []>>(
-                        writeMethodExp,
-                        instanceParam,
-                        levelParam,
-                        exceptionParam,
-                        messageParam,
-                        propertyValuesParam).Compile()
-                {
-                    Write = (fun logger level message formattedParmeters -> write.Invoke(logger,level,message,formattedParmeters))
-                    WriteException = fun logger level ex message formattedParmeters -> writeException.Invoke(logger,level,ex,message,formattedParmeters)
-                    IsEnabled = fun logger level -> isEnabled.Invoke(logger,level)
-                    TranslateLevel = translateLevel
-                }
-
-        type private SerigLogProvider () =
-            let getLoggerByName = getForContextMethodCall ()
-            let pushProperty = getPushProperty()
-            let serilogGatewayInit = lazy(SerilogGateway.Create())
-
-            let writeMessage logger logLevel (messageFunc : MessageThunk) ``exception`` formatParams =
-                let serilogGateway = serilogGatewayInit.Value
-                let translatedValue = serilogGateway.TranslateLevel logLevel
-                match messageFunc with
-                | None -> serilogGateway.IsEnabled logger translatedValue
-                | Some _ when  serilogGateway.IsEnabled logger translatedValue |> not -> false
-                | Some m ->
-                    match ``exception`` with
-                    | Some ex ->
-                        serilogGateway.WriteException logger translatedValue ex (m()) formatParams
-                    | None ->
-                        serilogGateway.Write logger translatedValue (m()) formatParams
-                    true
-
-            interface ILogProvider with
-                member this.GetLogger(name: string): Logger =
-                    getLoggerByName name
-                    |> writeMessage
-                member this.OpenMappedContext(key: string) (value: obj) (destructure: bool): IDisposable =
-                    pushProperty key value destructure
-                member this.OpenNestedContext(message: string): IDisposable =
-                    pushProperty "NDC" message false
-
-        let create () =
-            SerigLogProvider () :> ILogProvider
+      fun key value destructure -> pushProperty.Invoke(key, value, destructure)
 
 
+    let getForContextMethodCall () =
+      let logManagerType = getLogManagerType ()
+      let method = logManagerType.GetMethod("ForContext", [| typedefof<string>; typedefof<obj>; typedefof<bool> |])
+      let propertyNameParam = Expression.Parameter(typedefof<string>, "propertyName")
+      let valueParam = Expression.Parameter(typedefof<obj>, "value")
+      let destructureObjectsParam = Expression.Parameter(typedefof<bool>, "destructureObjects")
+      let exrs: Expression [] = [| propertyNameParam; valueParam; destructureObjectsParam |]
+      let methodCall = Expression.Call(null, method, exrs)
+
+      let func =
+        Expression
+          .Lambda<Func<string, obj, bool, obj>>(methodCall, propertyNameParam, valueParam, destructureObjectsParam)
+          .Compile()
+
+      fun name -> func.Invoke("SourceContext", name, false)
+
+    type SerilogGateway =
+      { Write: obj -> obj -> string -> obj [] -> unit
+        WriteException: obj -> obj -> exn -> string -> obj [] -> unit
+        IsEnabled: obj -> obj -> bool
+        TranslateLevel: LogLevel -> obj }
+      static member Create() =
+        let logEventLevelType = Type.GetType("Serilog.Events.LogEventLevel, Serilog")
+
+        if (logEventLevelType |> isNull) then
+          failwith ("Type Serilog.Events.LogEventLevel was not found.")
+
+        let debugLevel = Enum.Parse(logEventLevelType, "Debug", false)
+        let errorLevel = Enum.Parse(logEventLevelType, "Error", false)
+        let fatalLevel = Enum.Parse(logEventLevelType, "Fatal", false)
+        let informationLevel = Enum.Parse(logEventLevelType, "Information", false)
+        let verboseLevel = Enum.Parse(logEventLevelType, "Verbose", false)
+        let warningLevel = Enum.Parse(logEventLevelType, "Warning", false)
+
+        let translateLevel (level: LogLevel) =
+          match level with
+          | LogLevel.Fatal -> fatalLevel
+          | LogLevel.Error -> errorLevel
+          | LogLevel.Warn -> warningLevel
+          | LogLevel.Info -> informationLevel
+          | LogLevel.Debug -> debugLevel
+          | LogLevel.Trace -> verboseLevel
+          | _ -> debugLevel
+
+        let loggerType = Type.GetType("Serilog.ILogger, Serilog")
+
+        if (loggerType |> isNull) then
+          failwith ("Type Serilog.ILogger was not found.")
+
+        let isEnabledMethodInfo = loggerType.GetMethod("IsEnabled", [| logEventLevelType |])
+        let instanceParam = Expression.Parameter(typedefof<obj>)
+        let instanceCast = Expression.Convert(instanceParam, loggerType)
+        let levelParam = Expression.Parameter(typedefof<obj>)
+        let levelCast = Expression.Convert(levelParam, logEventLevelType)
+        let isEnabledMethodCall = Expression.Call(instanceCast, isEnabledMethodInfo, levelCast)
+
+        let isEnabled =
+          Expression.Lambda<Func<obj, obj, bool>>(isEnabledMethodCall, instanceParam, levelParam).Compile()
+
+        let writeMethodInfo =
+          loggerType.GetMethod("Write", [| logEventLevelType; typedefof<string>; typedefof<obj []> |])
+
+        let messageParam = Expression.Parameter(typedefof<string>)
+        let propertyValuesParam = Expression.Parameter(typedefof<obj []>)
+
+        let writeMethodExp =
+          Expression.Call(instanceCast, writeMethodInfo, levelCast, messageParam, propertyValuesParam)
+
+        let expression =
+          Expression.Lambda<Action<obj, obj, string, obj []>>(
+            writeMethodExp,
+            instanceParam,
+            levelParam,
+            messageParam,
+            propertyValuesParam
+          )
+
+        let write = expression.Compile()
+
+        let writeExceptionMethodInfo =
+          loggerType.GetMethod("Write", [| logEventLevelType; typedefof<exn>; typedefof<string>; typedefof<obj []> |])
+
+        let exceptionParam = Expression.Parameter(typedefof<exn>)
+
+        let writeMethodExp =
+          Expression.Call(
+            instanceCast,
+            writeExceptionMethodInfo,
+            levelCast,
+            exceptionParam,
+            messageParam,
+            propertyValuesParam
+          )
+
+        let writeException =
+          Expression
+            .Lambda<Action<obj, obj, exn, string, obj []>>(
+              writeMethodExp,
+              instanceParam,
+              levelParam,
+              exceptionParam,
+              messageParam,
+              propertyValuesParam
+            )
+            .Compile()
+
+        { Write =
+            (fun logger level message formattedParmeters -> write.Invoke(logger, level, message, formattedParmeters))
+          WriteException =
+            fun logger level ex message formattedParmeters ->
+              writeException.Invoke(logger, level, ex, message, formattedParmeters)
+          IsEnabled = fun logger level -> isEnabled.Invoke(logger, level)
+          TranslateLevel = translateLevel }
+
+    type private SerigLogProvider() =
+      let getLoggerByName = getForContextMethodCall ()
+      let pushProperty = getPushProperty ()
+      let serilogGatewayInit = lazy (SerilogGateway.Create())
+
+      let writeMessage logger logLevel (messageFunc: MessageThunk) ``exception`` formatParams =
+        let serilogGateway = serilogGatewayInit.Value
+        let translatedValue = serilogGateway.TranslateLevel logLevel
+
+        match messageFunc with
+        | None -> serilogGateway.IsEnabled logger translatedValue
+        | Some _ when serilogGateway.IsEnabled logger translatedValue |> not -> false
+        | Some m ->
+          match ``exception`` with
+          | Some ex -> serilogGateway.WriteException logger translatedValue ex (m ()) formatParams
+          | None -> serilogGateway.Write logger translatedValue (m ()) formatParams
+
+          true
+
+      interface ILogProvider with
+        member this.GetLogger(name: string) : Logger = getLoggerByName name |> writeMessage
+
+        member this.OpenMappedContext (key: string) (value: obj) (destructure: bool) : IDisposable =
+          pushProperty key value destructure
+
+        member this.OpenNestedContext(message: string) : IDisposable = pushProperty "NDC" message false
+
+    let create () = SerigLogProvider() :> ILogProvider
 
 module LogProvider =
-    open System
-    open Types
-    open Providers
-    open System.Diagnostics
-    open Microsoft.FSharp.Quotations.Patterns
+  open System
+  open Types
+  open Providers
+  open System.Diagnostics
+  open Microsoft.FSharp.Quotations.Patterns
 
-    let mutable private currentLogProvider = None
+  let mutable private currentLogProvider = None
 
-    let private knownProviders = [
-        (SerilogProvider.isAvailable , SerilogProvider.create)
-    ]
+  let private knownProviders = [ (SerilogProvider.isAvailable, SerilogProvider.create) ]
 
-    /// Greedy search for first available LogProvider. Order of known providers matters.
-    let private resolvedLogger = lazy (
-        knownProviders
-        |> Seq.tryFind(fun (isAvailable,_) -> isAvailable ())
-        |> Option.map(fun (_, create) -> create())
-    )
+  /// Greedy search for first available LogProvider. Order of known providers matters.
+  let private resolvedLogger =
+    lazy
+      (knownProviders
+       |> Seq.tryFind (fun (isAvailable, _) -> isAvailable ())
+       |> Option.map (fun (_, create) -> create ()))
 
-    let private noopLogger _ _ _ _ = false
+  let private noopLogger _ _ _ _ = false
 
-    let private noopDisposable = {
-        new IDisposable with
-            member __.Dispose() = ()
-    }
+  let private noopDisposable =
+    { new IDisposable with
+        member __.Dispose() = () }
 
-    /// **Description**
-    ///
-    /// Allows custom override when `getLogger` searches for a LogProvider.
-    ///
-    /// **Parameters**
-    ///   * `provider` - parameter of type `ILogProvider`
-    ///
-    /// **Output Type**
-    ///   * `unit`
-    let setLoggerProvider (logProvider : ILogProvider) =
-        currentLogProvider <- Some logProvider
+  /// **Description**
+  ///
+  /// Allows custom override when `getLogger` searches for a LogProvider.
+  ///
+  /// **Parameters**
+  ///   * `provider` - parameter of type `ILogProvider`
+  ///
+  /// **Output Type**
+  ///   * `unit`
+  let setLoggerProvider (logProvider: ILogProvider) = currentLogProvider <- Some logProvider
 
-    let getCurrentLogProvider () =
-        match currentLogProvider with
-        | None -> resolvedLogger.Value
-        | Some p -> Some p
+  let getCurrentLogProvider () =
+    match currentLogProvider with
+    | None -> resolvedLogger.Value
+    | Some p -> Some p
 
-    /// **Description**
-    ///
-    /// Opens a mapped diagnostic context.  This will allow you to set additional parameters to a log given a scope.
-    ///
-    /// **Parameters**
-    ///   * `key` - parameter of type `string` - The name of the property.
-    ///   * `value` - parameter of type `obj` - The value of the property.
-    ///   * `destructureObjects` - parameter of type `bool` - If true, and the value is a non-primitive, non-array type, then the value will be converted to a structure; otherwise, unknown types will be converted to scalars, which are generally stored as strings. WARNING: Destructring can be expensive.
-    ///
-    /// **Output Type**
-    ///   * `IDisposable`
-    let openMappedContextDestucturable (key : string) (value : obj) (destructureObjects : bool) =
-        let provider  = getCurrentLogProvider ()
-        match provider with
-        | Some p ->
-            p.OpenMappedContext key value destructureObjects
-        | None ->
-            noopDisposable
+  /// **Description**
+  ///
+  /// Opens a mapped diagnostic context.  This will allow you to set additional parameters to a log given a scope.
+  ///
+  /// **Parameters**
+  ///   * `key` - parameter of type `string` - The name of the property.
+  ///   * `value` - parameter of type `obj` - The value of the property.
+  ///   * `destructureObjects` - parameter of type `bool` - If true, and the value is a non-primitive, non-array type, then the value will be converted to a structure; otherwise, unknown types will be converted to scalars, which are generally stored as strings. WARNING: Destructring can be expensive.
+  ///
+  /// **Output Type**
+  ///   * `IDisposable`
+  let openMappedContextDestucturable (key: string) (value: obj) (destructureObjects: bool) =
+    let provider = getCurrentLogProvider ()
 
-    /// **Description**
-    ///
-    /// Opens a mapped diagnostic context.  This will allow you to set additional parameters to a log given a scope. Sets destructureObjects to false.
-    ///
-    /// **Parameters**
-    ///   * `key` - parameter of type `string` - The name of the property.
-    ///   * `value` - parameter of type `obj` - The value of the property.
-    ///
-    /// **Output Type**
-    ///   * `IDisposable`
-    let openMappedContext (key : string) (value : obj) =
-        //TODO: We should try to find out if the value is a primitive
-        openMappedContextDestucturable key value false
+    match provider with
+    | Some p -> p.OpenMappedContext key value destructureObjects
+    | None -> noopDisposable
 
-    /// **Description**
-    ///
-    /// Opens a nested diagnostic context.  This will allow you to set additional parameters to a log given a scope.
-    ///
-    /// **Parameters**
-    ///   * `value` - parameter of type `string` - The value of the property.
-    ///
-    /// **Output Type**
-    ///   * `IDisposable`
-    let openNestedContext (value : string) =
-        let provider  = getCurrentLogProvider ()
-        match provider with
-        | Some p ->
-            p.OpenNestedContext value
-        | None ->
-            noopDisposable
+  /// **Description**
+  ///
+  /// Opens a mapped diagnostic context.  This will allow you to set additional parameters to a log given a scope. Sets destructureObjects to false.
+  ///
+  /// **Parameters**
+  ///   * `key` - parameter of type `string` - The name of the property.
+  ///   * `value` - parameter of type `obj` - The value of the property.
+  ///
+  /// **Output Type**
+  ///   * `IDisposable`
+  let openMappedContext (key: string) (value: obj) =
+    //TODO: We should try to find out if the value is a primitive
+    openMappedContextDestucturable key value false
 
-    /// **Description**
-    ///
-    /// Creates a logger given a `string`.  This will attempt to retrieve any loggers set with `setLoggerProvider`.  It will fallback to a known list of providers.
-    ///
-    /// **Parameters**
-    ///   * `string` - parameter of type `string`
-    ///
-    /// **Output Type**
-    ///   * `ILog`
-    let getLoggerByName (name : string) =
-        let loggerProvider = getCurrentLogProvider ()
+  /// **Description**
+  ///
+  /// Opens a nested diagnostic context.  This will allow you to set additional parameters to a log given a scope.
+  ///
+  /// **Parameters**
+  ///   * `value` - parameter of type `string` - The value of the property.
+  ///
+  /// **Output Type**
+  ///   * `IDisposable`
+  let openNestedContext (value: string) =
+    let provider = getCurrentLogProvider ()
 
-        let logFunc =
-            match loggerProvider with
-            | Some loggerProvider -> loggerProvider.GetLogger(name)
-            | None -> noopLogger
+    match provider with
+    | Some p -> p.OpenNestedContext value
+    | None -> noopDisposable
 
-        { new ILog
-            with
-                member x.Log = logFunc
-                member x.MappedContext = openMappedContextDestucturable}
+  /// **Description**
+  ///
+  /// Creates a logger given a `string`.  This will attempt to retrieve any loggers set with `setLoggerProvider`.  It will fallback to a known list of providers.
+  ///
+  /// **Parameters**
+  ///   * `string` - parameter of type `string`
+  ///
+  /// **Output Type**
+  ///   * `ILog`
+  let getLoggerByName (name: string) =
+    let loggerProvider = getCurrentLogProvider ()
 
-    /// **Description**
-    ///
-    /// Creates a logger given a `Type`.  This will attempt to retrieve any loggers set with `setLoggerProvider`.  It will fallback to a known list of providers.
-    ///
-    /// **Parameters**
-    ///   * `type` - parameter of type `Type`
-    ///
-    /// **Output Type**
-    ///   * `ILog`
-    let getLoggerByType (``type`` : Type) =
-        ``type``
-        |> string
-        |> getLoggerByName
+    let logFunc =
+      match loggerProvider with
+      | Some loggerProvider -> loggerProvider.GetLogger(name)
+      | None -> noopLogger
 
-    /// **Description**
-    ///
-    /// Creates a logger given a `'a` type. This will attempt to retrieve any loggers set with `setLoggerProvider`.  It will fallback to a known list of providers.
-    ///
-    /// **Output Type**
-    ///   * `ILog`
-    ///
-    let getLoggerFor<'a> () =
-        getLoggerByType(typeof<'a>)
+    { new ILog with
+        member x.Log = logFunc
+        member x.MappedContext = openMappedContextDestucturable }
 
-    let rec getModuleType =
-        function
-        | PropertyGet (_, propertyInfo, _) -> propertyInfo.DeclaringType
-        // | Call (_, methInfo, _) -> sprintf "%s.%s" methInfo.DeclaringType.FullName methInfo.Name
-        // | Lambda(_, expr) -> getModuleType expr
-        // | ValueWithName(_,_,instance) -> instance
-        | x -> failwithf "Expression is not a property. %A" x
+  /// **Description**
+  ///
+  /// Creates a logger given a `Type`.  This will attempt to retrieve any loggers set with `setLoggerProvider`.  It will fallback to a known list of providers.
+  ///
+  /// **Parameters**
+  ///   * `type` - parameter of type `Type`
+  ///
+  /// **Output Type**
+  ///   * `ILog`
+  let getLoggerByType (``type``: Type) = ``type`` |> string |> getLoggerByName
 
-    /// **Description**
-    ///
-    /// Creates a logger given a Quotations.Expr type. This is only useful for module level declarations. It uses the DeclaringType on the PropertyInfo of the PropertyGet.
-    ///
-    /// It can be utilized like:
-    ///
-    /// `let rec logger = LogProvider.getLoggerByQuotation <@ logger @>`
-    ///
-    /// inside a module to get the modules full qualitfied name.
-    ///
-    /// **Parameters**
-    ///   * `quotation` - parameter of type `Quotations.Expr`
-    ///
-    /// **Output Type**
-    ///   * `ILog`
-    ///
-    /// **Exceptions**
-    ///
-    let getLoggerByQuotation (quotation : Quotations.Expr) =
-        getModuleType quotation
-        |> getLoggerByType
+  /// **Description**
+  ///
+  /// Creates a logger given a `'a` type. This will attempt to retrieve any loggers set with `setLoggerProvider`.  It will fallback to a known list of providers.
+  ///
+  /// **Output Type**
+  ///   * `ILog`
+  ///
+  let getLoggerFor<'a> () = getLoggerByType (typeof<'a>)
+
+  let rec getModuleType =
+    function
+    | PropertyGet (_, propertyInfo, _) -> propertyInfo.DeclaringType
+    // | Call (_, methInfo, _) -> sprintf "%s.%s" methInfo.DeclaringType.FullName methInfo.Name
+    // | Lambda(_, expr) -> getModuleType expr
+    // | ValueWithName(_,_,instance) -> instance
+    | x -> failwithf "Expression is not a property. %A" x
+
+  /// **Description**
+  ///
+  /// Creates a logger given a Quotations.Expr type. This is only useful for module level declarations. It uses the DeclaringType on the PropertyInfo of the PropertyGet.
+  ///
+  /// It can be utilized like:
+  ///
+  /// `let rec logger = LogProvider.getLoggerByQuotation <@ logger @>`
+  ///
+  /// inside a module to get the modules full qualitfied name.
+  ///
+  /// **Parameters**
+  ///   * `quotation` - parameter of type `Quotations.Expr`
+  ///
+  /// **Output Type**
+  ///   * `ILog`
+  ///
+  /// **Exceptions**
+  ///
+  let getLoggerByQuotation (quotation: Quotations.Expr) = getModuleType quotation |> getLoggerByType
 
 
 
-    /// **Description**
-    ///
-    /// Creates a logger based on `Reflection.MethodBase.GetCurrentMethod` call.  This is only useful for calls within functions.  This does not protect against inlined functions.
-    ///
-    /// **Output Type**
-    ///   * `ILog`
-    ///
-    /// **Exceptions**
-    ///
-    let inline getLoggerByFunc () =
-        let mi = Reflection.MethodBase.GetCurrentMethod()
-        sprintf "%s.%s" mi.DeclaringType.FullName mi.Name
-        |> getLoggerByName
+  /// **Description**
+  ///
+  /// Creates a logger based on `Reflection.MethodBase.GetCurrentMethod` call.  This is only useful for calls within functions.  This does not protect against inlined functions.
+  ///
+  /// **Output Type**
+  ///   * `ILog`
+  ///
+  /// **Exceptions**
+  ///
+  let inline getLoggerByFunc () =
+    let mi = Reflection.MethodBase.GetCurrentMethod()
+
+    sprintf "%s.%s" mi.DeclaringType.FullName mi.Name
+    |> getLoggerByName
 
 
-    /// **Description**
-    ///
-    /// Creates a logger. It's name is based on the current StackFrame. This will attempt to retrieve any loggers set with `setLoggerProvider`.  It will fallback to a known list of providers.
-    /// Obsolete: getCurrentLogger is obsolete, choose another provider factory function.
-    ///
-    /// **Output Type**
-    ///   * `ILog`
-    [<Obsolete("getCurrentLogger is obsolete, choose another provider factory function")>]
-    let getCurrentLogger ()   =
-        let stackFrame = StackFrame(2, false)
-        getLoggerByType(stackFrame.GetMethod().DeclaringType)
-
+  /// **Description**
+  ///
+  /// Creates a logger. It's name is based on the current StackFrame. This will attempt to retrieve any loggers set with `setLoggerProvider`.  It will fallback to a known list of providers.
+  /// Obsolete: getCurrentLogger is obsolete, choose another provider factory function.
+  ///
+  /// **Output Type**
+  ///   * `ILog`
+  [<Obsolete("getCurrentLogger is obsolete, choose another provider factory function")>]
+  let getCurrentLogger () =
+    let stackFrame = StackFrame(2, false)
+    getLoggerByType (stackFrame.GetMethod().DeclaringType)

--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -18,12 +18,16 @@
          Namespace changed from FsLibLog to LanguageServerProtocol.Logging per the instructions in that repo.
     -->
     <Compile Include="FsLibLog.fs" />
+    <Compile Include="JsonRpc.fs" />
+    <Compile Include="Types.fs" />
+    <Compile Include="Client.fs" />
+    <Compile Include="Server.fs" />
     <Compile Include="LanguageServerProtocol.fs" />
     <None Include="../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>
-    <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" PrivateAssets="All"/>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <!-- Explicitly pinning our FSharp.Core to 6.0.0 so that consumers can use _any_ 6.x version. -->
     <PackageReference Update="FSharp.Core" Version="6.0.0" />

--- a/src/JsonRpc.fs
+++ b/src/JsonRpc.fs
@@ -1,0 +1,77 @@
+module Ionide.LanguageServerProtocol.JsonRpc
+
+open Newtonsoft.Json
+open Newtonsoft.Json.Linq
+
+type MessageTypeTest =
+  { [<JsonProperty("jsonrpc")>]
+    Version: string
+    Id: int option
+    Method: string option }
+
+[<RequireQualifiedAccess>]
+type MessageType =
+  | Notification
+  | Request
+  | Response
+  | Error
+
+let getMessageType messageTest =
+  match messageTest with
+  | { Version = "2.0"; Id = Some _; Method = Some _ } -> MessageType.Request
+  | { Version = "2.0"; Id = Some _; Method = None } -> MessageType.Response
+  | { Version = "2.0"; Id = None; Method = Some _ } -> MessageType.Notification
+  | _ -> MessageType.Error
+
+type Request =
+  { [<JsonProperty("jsonrpc")>]
+    Version: string
+    Id: int
+    Method: string
+    Params: JToken option }
+  static member Create(id: int, method': string, rpcParams: JToken option) =
+    { Version = "2.0"; Id = id; Method = method'; Params = rpcParams }
+
+type Notification =
+  { [<JsonProperty("jsonrpc")>]
+    Version: string
+    Method: string
+    Params: JToken option }
+  static member Create(method': string, rpcParams: JToken option) =
+    { Version = "2.0"; Method = method'; Params = rpcParams }
+
+module ErrorCodes =
+  let parseError = -32700
+  let invalidRequest = -32600
+  let methodNotFound = -32601
+  let invalidParams = -32602
+  let internalError = -32603
+  let serverErrorStart = -32000
+  let serverErrorEnd = -32099
+
+type Error =
+  { Code: int
+    Message: string
+    Data: JToken option }
+  static member Create(code: int, message: string) = { Code = code; Message = message; Data = None }
+  static member ParseError = Error.Create(ErrorCodes.parseError, "Parse error")
+  static member InvalidRequest = Error.Create(ErrorCodes.invalidRequest, "Invalid Request")
+  static member MethodNotFound = Error.Create(ErrorCodes.methodNotFound, "Method not found")
+  static member InvalidParams = Error.Create(ErrorCodes.invalidParams, "Invalid params")
+  static member InternalError = Error.Create(ErrorCodes.internalError, "Internal error")
+  static member InternalErrorMessage message = Error.Create(ErrorCodes.internalError, message)
+
+type Response =
+  { [<JsonProperty("jsonrpc")>]
+    Version: string
+    Id: int option
+    Error: Error option
+    [<JsonProperty(NullValueHandling = NullValueHandling.Include)>]
+    Result: JToken option }
+  /// Json.NET conditional property serialization, controlled by naming convention
+  member x.ShouldSerializeResult() = x.Error.IsNone
+
+  static member Success(id: int, result: JToken option) =
+    { Version = "2.0"; Id = Some id; Result = result; Error = None }
+
+  static member Failure(id: int, error: Error) = { Version = "2.0"; Id = Some id; Result = None; Error = Some error }

--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -1,2356 +1,405 @@
-module Ionide.LanguageServerProtocol
+namespace Ionide.LanguageServerProtocol
 
-open System.Diagnostics
-
-
-[<AutoOpen>]
 module LspJsonConverters =
-    open Microsoft.FSharp.Reflection
-    open Newtonsoft.Json
-    open System
-    open System.Collections.Concurrent
+  open Microsoft.FSharp.Reflection
+  open Newtonsoft.Json
+  open System
+  open System.Collections.Concurrent
+  open Ionide.LanguageServerProtocol.Types
 
-    let inline memorise (f: 'a -> 'b) : ('a -> 'b) =
-        let d = ConcurrentDictionary<'a, 'b>()
-        fun key ->
-            d.GetOrAdd(key, f)
+  let inline memorise (f: 'a -> 'b) : ('a -> 'b) =
+    let d = ConcurrentDictionary<'a, 'b>()
+    fun key -> d.GetOrAdd(key, f)
 
-    type ErasedUnionAttribute() =
-        inherit Attribute()
+  type ErasedUnionConverter() =
+    inherit JsonConverter()
 
-    [<ErasedUnion>]
-    type U2<'a, 'b> = First of 'a | Second of 'b
+    let canConvert =
+      memorise (fun t ->
+        if not (FSharpType.IsUnion t) then
+          false
+        else
+          t.BaseType.GetCustomAttributes(typedefof<ErasedUnionAttribute>, false).Length > 0)
 
-    type ErasedUnionConverter() =
-        inherit JsonConverter()
+    override __.CanConvert(t) = canConvert t
 
-        let canConvert =
-            memorise (fun t ->
-                if not (FSharpType.IsUnion t) then
-                    false
-                else
-                    t.BaseType.GetCustomAttributes(typedefof<ErasedUnionAttribute>, false).Length > 0)
+    override __.WriteJson(writer, value, serializer) =
+      let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
+      let unionField = fields.[0]
+      serializer.Serialize(writer, unionField)
 
-        override __.CanConvert(t) = canConvert t
+    override __.ReadJson(_reader, _t, _existingValue, _serializer) = failwith "Not implemented"
 
-        override __.WriteJson(writer, value, serializer) =
-            let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
-            let unionField = fields.[0]
-            serializer.Serialize(writer, unionField)
-
-        override __.ReadJson(_reader, _t, _existingValue, _serializer) =
-            failwith "Not implemented"
-
-    /// converter that can convert enum-style DUs
-    type SingleCaseUnionConverter() =
-      inherit JsonConverter()
+  /// converter that can convert enum-style DUs
+  type SingleCaseUnionConverter() =
+    inherit JsonConverter()
 
 
-      let canConvert =
-        let allCases (t: System.Type) =
-          FSharpType.GetUnionCases t
-        memorise (fun t ->
-          FSharpType.IsUnion t
-          && allCases t |> Array.forall (fun c -> c.GetFields().Length = 0)
-        )
+    let canConvert =
+      let allCases (t: System.Type) = FSharpType.GetUnionCases t
 
-      override _.CanConvert t = canConvert t
+      memorise (fun t ->
+        FSharpType.IsUnion t
+        && allCases t
+           |> Array.forall (fun c -> c.GetFields().Length = 0))
 
-      override _.WriteJson(writer: Newtonsoft.Json.JsonWriter, value: obj, serializer: Newtonsoft.Json.JsonSerializer) =
-        serializer.Serialize(writer, string value)
+    override _.CanConvert t = canConvert t
 
-      override _.ReadJson(reader: Newtonsoft.Json.JsonReader, t, _existingValue, serializer) =
-        let caseName = string reader.Value
-        match FSharpType.GetUnionCases(t) |> Array.tryFind (fun c -> c.Name.Equals(caseName, StringComparison.OrdinalIgnoreCase)) with
-        | Some caseInfo ->
-          FSharpValue.MakeUnion(caseInfo, [||])
-        | None ->
-          failwith $"Could not create an instance of the type '%s{t.Name}' with the name '%s{caseName}'"
+    override _.WriteJson(writer: Newtonsoft.Json.JsonWriter, value: obj, serializer: Newtonsoft.Json.JsonSerializer) =
+      serializer.Serialize(writer, string value)
 
-    type U2BoolObjectConverter() =
-      inherit JsonConverter()
+    override _.ReadJson(reader: Newtonsoft.Json.JsonReader, t, _existingValue, serializer) =
+      let caseName = string reader.Value
 
-      let canConvert =
-        memorise (fun (t: System.Type) ->
-          t.IsGenericType
-          && t.GetGenericTypeDefinition() = typedefof<U2<_, _>>
-          && t.GetGenericArguments().Length = 2
-          && t.GetGenericArguments().[0] = typeof<bool>
-          && not (t.GetGenericArguments().[1].IsValueType)
-        )
+      match
+        FSharpType.GetUnionCases(t)
+        |> Array.tryFind (fun c -> c.Name.Equals(caseName, StringComparison.OrdinalIgnoreCase))
+        with
+      | Some caseInfo -> FSharpValue.MakeUnion(caseInfo, [||])
+      | None -> failwith $"Could not create an instance of the type '%s{t.Name}' with the name '%s{caseName}'"
 
-      override _.CanConvert t = canConvert t
+  type U2BoolObjectConverter() =
+    inherit JsonConverter()
 
-      override _.WriteJson(writer, value, serializer) =
-        let case, fields = FSharpValue.GetUnionFields(value, value.GetType())
-        match case.Name with
-        | "First" ->
-          writer.WriteValue(value :?> bool)
-        | "Second" ->
-          serializer.Serialize(writer, fields.[0])
-        | _ ->
-          failwith $"Unrecognized case '{case.Name}' for union type '{value.GetType().FullName}'."
+    let canConvert =
+      memorise (fun (t: System.Type) ->
+        t.IsGenericType
+        && t.GetGenericTypeDefinition() = typedefof<U2<_, _>>
+        && t.GetGenericArguments().Length = 2
+        && t.GetGenericArguments().[0] = typeof<bool>
+        && not (t.GetGenericArguments().[1].IsValueType))
 
-      override _.ReadJson(reader, t, _existingValue, serializer) =
-        let cases = FSharpType.GetUnionCases(t)
-        match reader.TokenType with
-        | JsonToken.Boolean ->
-          // 'First' side
-          FSharpValue.MakeUnion(cases.[0], [| box(reader.Value :?> bool) |])
-        | JsonToken.StartObject ->
-          // Second side
-          let value = serializer.Deserialize(reader, (t.GetGenericArguments().[1]))
-          FSharpValue.MakeUnion(cases.[1], [| value |])
-        | _ ->
-          failwithf $"Unrecognized json TokenType '%s{string reader.TokenType}' when reading value of type '{t.FullName}'"
+    override _.CanConvert t = canConvert t
 
-    type OptionConverter() =
-        inherit JsonConverter()
+    override _.WriteJson(writer, value, serializer) =
+      let case, fields = FSharpValue.GetUnionFields(value, value.GetType())
 
-        override __.CanConvert(t) =
-            t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
+      match case.Name with
+      | "First" -> writer.WriteValue(value :?> bool)
+      | "Second" -> serializer.Serialize(writer, fields.[0])
+      | _ -> failwith $"Unrecognized case '{case.Name}' for union type '{value.GetType().FullName}'."
 
-        override __.WriteJson(writer, value, serializer) =
-            let value =
-                if isNull value then null
-                else
-                    let _,fields = FSharpValue.GetUnionFields(value, value.GetType())
-                    fields.[0]
-            serializer.Serialize(writer, value)
+    override _.ReadJson(reader, t, _existingValue, serializer) =
+      let cases = FSharpType.GetUnionCases(t)
 
-        override __.ReadJson(reader, t, _existingValue, serializer) =
-            let innerType = t.GetGenericArguments().[0]
-            let innerType =
-                if innerType.IsValueType then (typedefof<Nullable<_>>).MakeGenericType([|innerType|])
-                else innerType
-            let value = serializer.Deserialize(reader, innerType)
-            let cases = FSharpType.GetUnionCases(t)
-            if isNull value then FSharpValue.MakeUnion(cases.[0], [||])
-            else FSharpValue.MakeUnion(cases.[1], [|value|])
+      match reader.TokenType with
+      | JsonToken.Boolean ->
+        // 'First' side
+        FSharpValue.MakeUnion(cases.[0], [| box (reader.Value :?> bool) |])
+      | JsonToken.StartObject ->
+        // Second side
+        let value = serializer.Deserialize(reader, (t.GetGenericArguments().[1]))
+        FSharpValue.MakeUnion(cases.[1], [| value |])
+      | _ ->
+        failwithf $"Unrecognized json TokenType '%s{string reader.TokenType}' when reading value of type '{t.FullName}'"
 
-module Types =
-    open Newtonsoft.Json
-    open Newtonsoft.Json.Linq
-    open System
+  type OptionConverter() =
+    inherit JsonConverter()
 
-    type TextDocumentSyncKind =
-        | None = 0
-        | Full = 1
-        | Incremental = 2
+    override __.CanConvert(t) =
+      t.IsGenericType
+      && t.GetGenericTypeDefinition() = typedefof<option<_>>
 
-    type DocumentFilter = {
-        /// A language id, like `typescript`.
-        Language: string option
+    override __.WriteJson(writer, value, serializer) =
+      let value =
+        if isNull value then
+          null
+        else
+          let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
+          fields.[0]
 
-        /// A Uri scheme, like `file` or `untitled`.
-        Scheme: string option
+      serializer.Serialize(writer, value)
 
-        /// A glob pattern, like `*.{ts,js}`.
-        Pattern: string option
-    }
+    override __.ReadJson(reader, t, _existingValue, serializer) =
+      let innerType = t.GetGenericArguments().[0]
 
-    type DocumentSelector = DocumentFilter[]
+      let innerType =
+        if innerType.IsValueType then
+          (typedefof<Nullable<_>>).MakeGenericType([| innerType |])
+        else
+          innerType
 
-    /// Position in a text document expressed as zero-based line and zero-based character offset.
-    /// A position is between two characters like an ‘insert’ cursor in a editor.
-    [<DebuggerDisplay("{DebuggerDisplay}")>]
-    type Position =
-      {
-          /// Line position in a document (zero-based).
-          Line: int
+      let value = serializer.Deserialize(reader, innerType)
+      let cases = FSharpType.GetUnionCases(t)
 
-          /// Character offset on a line in a document (zero-based). Assuming that the line is
-          /// represented as a string, the `character` value represents the gap between the
-          /// `character` and `character + 1`.
-          ///
-          /// If the character value is greater than the line length it defaults back to the
-          /// line length.
-          Character: int
-      }
-      [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
-      member x.DebuggerDisplay =
-        $"({x.Line},{x.Character})"
+      if isNull value then
+        FSharpValue.MakeUnion(cases.[0], [||])
+      else
+        FSharpValue.MakeUnion(cases.[1], [| value |])
 
-    /// A range in a text document expressed as (zero-based) start and end positions.
-    /// A range is comparable to a selection in an editor. Therefore the end position is exclusive.
-    ///
-    /// If you want to specify a range that contains a line including the line ending character(s)
-    /// then use an end position denoting the start of the next line. For example:
-    ///
-    /// ```fsharp
-    /// {
-    ///     Start = { Line = 5; character = 23 }
-    ///     End = { Line = 6; character = 0 }
-    /// }
-    /// ```
-    [<DebuggerDisplay("{DebuggerDisplay}")>]
-    type Range =
-      {
-          /// The range's start position.
-          Start: Position
 
-          /// The range's end position.
-          End: Position
-      }
-      [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
-      member x.DebuggerDisplay =
-        $"{x.Start.DebuggerDisplay}-{x.End.DebuggerDisplay}"
+module Server =
+  open System
+  open System.IO
+  open Ionide.LanguageServerProtocol.Logging
+  open Ionide.LanguageServerProtocol.Types
+  open System.Threading
+  open System.Threading.Tasks
+  open System.Reflection
+  open StreamJsonRpc
+  open Newtonsoft.Json
+  open Newtonsoft.Json.Serialization
+  open LspJsonConverters
+  open Newtonsoft.Json.Linq
 
-    type DocumentUri = string
+  let logger = LogProvider.getLoggerByName "LSP Server"
 
-    /// Represents a location inside a resource, such as a line inside a text file.
-    type Location = {
-        Uri: DocumentUri
-        Range: Range
-    }
+  let jsonRpcFormatter = new JsonMessageFormatter()
+  jsonRpcFormatter.JsonSerializer.NullValueHandling <- NullValueHandling.Ignore
+  jsonRpcFormatter.JsonSerializer.ConstructorHandling <- ConstructorHandling.AllowNonPublicDefaultConstructor
+  jsonRpcFormatter.JsonSerializer.MissingMemberHandling <- MissingMemberHandling.Ignore
+  jsonRpcFormatter.JsonSerializer.Converters.Add(SingleCaseUnionConverter())
+  jsonRpcFormatter.JsonSerializer.Converters.Add(U2BoolObjectConverter())
+  jsonRpcFormatter.JsonSerializer.Converters.Add(OptionConverter())
+  jsonRpcFormatter.JsonSerializer.Converters.Add(ErasedUnionConverter())
+  jsonRpcFormatter.JsonSerializer.ContractResolver <- CamelCasePropertyNamesContractResolver()
 
-    type ITextDocumentIdentifier =
-        /// Warning: normalize this member by UrlDecoding it before use
-        abstract member Uri : DocumentUri with get
+  let deserialize<'t> (token: JToken) = token.ToObject<'t>(jsonRpcFormatter.JsonSerializer)
+  let serialize<'t> (o: 't) = JToken.FromObject(o, jsonRpcFormatter.JsonSerializer)
 
-    type TextDocumentIdentifier =
-        {
-            /// The text document's URI.
-            Uri: DocumentUri
+  let requestHandling<'param, 'result> (run: 'param -> AsyncLspResult<'result>) : Delegate =
+    let runAsTask param ct =
+      let asyncLspResult = run param
+
+      let asyncContinuation =
+        async {
+          let! lspResult = asyncLspResult
+
+          return
+            match lspResult with
+            | Ok result -> result
+            | Error error ->
+              let rpcException = LocalRpcException(error.Message)
+              rpcException.ErrorCode <- error.Code
+              rpcException.ErrorData <- error.Data |> Option.defaultValue null
+              raise rpcException
         }
-        interface ITextDocumentIdentifier with
-            member this.Uri with get() = this.Uri
 
-    type VersionedTextDocumentIdentifier =
-        {
-            /// The text document's URI.
-            Uri: DocumentUri
+      Async.StartAsTask(asyncContinuation, cancellationToken = ct)
 
-            /// The version number of this document. If a versioned text document identifier
-            /// is sent from the server to the client and the file is not open in the editor
-            /// (the server has not received an open notification before) the server can send
-            /// `null` to indicate that the version is known and the content on disk is the
-            /// truth (as speced with document content ownership)
-            /// Explicitly include the null value here.
-            [<JsonProperty(NullValueHandling = NullValueHandling.Include)>]
-            Version: int option
-        }
-        interface ITextDocumentIdentifier with
-            member this.Uri with get() = this.Uri
+    Func<'param, CancellationToken, Task<'result>>(runAsTask) :> Delegate
 
-    type SymbolKind =
-    | File = 1
-    | Module = 2
-    | Namespace = 3
-    | Package = 4
-    | Class = 5
-    | Method = 6
-    | Property = 7
-    | Field = 8
-    | Constructor = 9
-    | Enum = 10
-    | Interface = 11
-    | Function = 12
-    | Variable = 13
-    | Constant = 14
-    | String = 15
-    | Number = 16
-    | Boolean = 17
-    | Array = 18
-    | Object = 19
-    | Key = 20
-    | Null = 21
-    | EnumMember = 22
-    | Struct = 23
-    | Event = 24
-    | Operator = 25
-    | TypeParameter = 26
-
-    /// Represents information about programming constructs like variables, classes,
-    /// interfaces etc.
-    type SymbolInformation = {
-        /// The name of this symbol.
-        Name: string
-
-        /// The kind of this symbol.
-        Kind: SymbolKind
-
-        /// The location of this symbol. The location's range is used by a tool
-        /// to reveal the location in the editor. If the symbol is selected in the
-        /// tool the range's start information is used to position the cursor. So
-        /// the range usually spans more then the actual symbol's name and does
-        /// normally include things like visibility modifiers.
-        ///
-        /// The range doesn't have to denote a node range in the sense of a abstract
-        /// syntax tree. It can therefore not be used to re-construct a hierarchy of
-        /// the symbols.
-        Location: Location
-
-        /// The name of the symbol containing this symbol. This information is for
-        /// user interface purposes (e.g. to render a qualifier in the user interface
-        /// if necessary). It can't be used to re-infer a hierarchy for the document
-        /// symbols.
-        ContainerName: string option
-    }
-    
-    /// Represents programming constructs like variables, classes, interfaces etc.
-    /// that appear in a document. Document symbols can be hierarchical and they
-    /// have two ranges: one that encloses its definition and one that points to its
-    /// most interesting range, e.g. the range of an identifier.
-    type DocumentSymbol = {
-        /// The name of this symbol. Will be displayed in the user interface and
-        /// therefore must not be an empty string or a string only consisting of
-        /// white spaces.
-        Name: string
-        /// More detail for this symbol, e.g the signature of a function.
-        Detail: string option
-        /// The kind of this symbol.
-        Kind: SymbolKind
-        /// The range enclosing this symbol not including leading/trailing whitespace
-        /// but everything else like comments. This information is typically used to
-        /// determine if the clients cursor is inside the symbol to reveal in the
-        /// symbol in the UI.
-        Range: Range
-        /// The range that should be selected and revealed when this symbol is being
-        /// picked, e.g. the name of a function. Must be contained by the `range`.
-        SelectionRange: Range
-        /// Children of this symbol, e.g. properties of a class.
-        Children: DocumentSymbol[] option
-    }
-
-    /// A textual edit applicable to a text document.
-    type TextEdit = {
-        /// The range of the text document to be manipulated. To insert
-        /// text into a document create a range where start === end.
-        Range: Range
-
-        /// The string to be inserted. For delete operations use an
-        /// empty string.
-        NewText: string
-    }
-
-    /// Describes textual changes on a single text document. The text document is referred to as a
-    /// `VersionedTextDocumentIdentifier` to allow clients to check the text document version before an edit is
-    /// applied. A `TextDocumentEdit` describes all changes on a version Si and after they are applied move the
-    /// document to version Si+1. So the creator of a `TextDocumentEdit `doesn't need to sort the array or do any
-    /// kind of ordering. However the edits must be non overlapping.
-    type TextDocumentEdit = {
-        /// The text document to change.
-        TextDocument: VersionedTextDocumentIdentifier
-
-        /// The edits to be applied.
-        Edits: TextEdit[]
-    }
-
-    type TraceSetting =
-        | Off = 0
-        | Messages = 1
-        | Verbose = 2
-
-    /// Capabilities for methods that support dynamic registration.
-    type DynamicCapabilities = {
-        /// Method supports dynamic registration.
-        DynamicRegistration: bool option
-    }
-
-    type ResourceOperationKind = Create | Rename | Delete
-
-    type FailureHandlingKind = Abort | Transactional | Undo | TextOnlyTransactional
-
-    type ChangeAnnotationSupport = {
-      GroupsOnLabel: bool option
-    }
-
-    /// Capabilities specific to `WorkspaceEdit`s
-    type WorkspaceEditCapabilities = {
-        /// The client supports versioned document changes in `WorkspaceEdit`s
-        DocumentChanges: bool option
-        /// The resource operations the client supports. Clients should at least
-        /// support 'create', 'rename' and 'delete' files and folders.
-        ResourceOperations: ResourceOperationKind [] option
-        /// The failure handling strategy of a client if applying the workspace edit fails.
-        FailureHandling: FailureHandlingKind option
-        /// Whether the client normalizes line endings to the client specific setting.
-        /// If set to `true` the client will normalize line ending characters
-        /// in a workspace edit to the client specific new line character(s).
-        NormalizesLineEndings: bool option
-        /// Whether the client in general supports change annotations on text edits, create file, rename file and delete file changes.
-        ChangeAnnotationSupport: ChangeAnnotationSupport option
-    }
-
-    /// Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
-    type SymbolKindCapabilities = {
-        /// The symbol kind values the client supports. When this
-        /// property exists the client also guarantees that it will
-        /// handle values outside its set gracefully and falls back
-        /// to a default value when unknown.
-        ///
-        /// If this property is not present the client only supports
-        /// the symbol kinds from `File` to `Array` as defined in
-        /// the initial version of the protocol.
-        ValueSet: SymbolKind[] option
-    }
-    with
-        static member DefaultValueSet =
-            [|
-                SymbolKind.File
-                SymbolKind.Module
-                SymbolKind.Namespace
-                SymbolKind.Package
-                SymbolKind.Class
-                SymbolKind.Method
-                SymbolKind.Property
-                SymbolKind.Field
-                SymbolKind.Constructor
-                SymbolKind.Enum
-                SymbolKind.Interface
-                SymbolKind.Function
-                SymbolKind.Variable
-                SymbolKind.Constant
-                SymbolKind.String
-                SymbolKind.Number
-                SymbolKind.Boolean
-                SymbolKind.Array
-            |]
-
-    /// Capabilities specific to the `workspace/symbol` request.
-    type SymbolCapabilities = {
-        /// Symbol request supports dynamic registration.
-        DynamicRegistration: bool option
-
-        /// Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
-        SymbolKind: SymbolKindCapabilities option
-    }
-
-    type SemanticTokensWorkspaceClientCapabilities = {
-      /// Whether the client implementation supports a refresh request sent from
-      /// the server to the client.
-      ///
-      /// Note that this event is global and will force the client to refresh all
-      /// semantic tokens currently shown. It should be used with absolute care
-      /// and is useful for situation where a server for example detect a project
-      /// wide change that requires such a calculation.
-      RefreshSupport: bool option
-    }
-
-    /// Workspace specific client capabilities.
-    type WorkspaceClientCapabilities = {
-        /// The client supports applying batch edits to the workspace by supporting
-        /// the request 'workspace/applyEdit'
-        ApplyEdit: bool option
-
-        /// Capabilities specific to `WorkspaceEdit`s
-        WorkspaceEdit: WorkspaceEditCapabilities option
-
-        /// Capabilities specific to the `workspace/didChangeConfiguration` notification.
-        DidChangeConfiguration: DynamicCapabilities option
-
-        /// Capabilities specific to the `workspace/didChangeWatchedFiles` notification.
-        DidChangeWatchedFiles: DynamicCapabilities option
-
-        /// Capabilities specific to the `workspace/symbol` request.
-        Symbol: SymbolCapabilities option
-
-        SemanticTokens: SemanticTokensWorkspaceClientCapabilities option
-    }
-
-    type SynchronizationCapabilities = {
-        /// Whether text document synchronization supports dynamic registration.
-        DynamicRegistration: bool option
-
-        /// The client supports sending will save notifications.
-        WillSave: bool option
-
-        /// The client supports sending a will save request and
-        /// waits for a response providing text edits which will
-        /// be applied to the document before it is saved.
-        WillSaveWaitUntil: bool option
-
-        /// The client supports did save notifications.
-        DidSave: bool option
-    }
-
-    module MarkupKind =
-        let PlainText = "plaintext"
-        let Markdown = "markdown"
-
-    type HoverCapabilities = {
-        /// Whether hover synchronization supports dynamic registration.
-        DynamicRegistration: bool option
-
-        /// Client supports the follow content formats for the content
-        /// property. The order describes the preferred format of the client.
-        /// See `MarkupKind` for common values
-        ContentFormat: string[] option
-    }
-
-    type CompletionItemCapabilities = {
-        /// Client supports snippets as insert text.
-        ///
-        /// A snippet can define tab stops and placeholders with `$1`, `$2`
-        /// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
-        /// the end of the snippet. Placeholders with equal identifiers are linked,
-        /// that is typing in one will update others too.
-        SnippetSupport: bool option
-
-        /// Client supports commit characters on a completion item.
-        CommitCharactersSupport: bool option
-
-        /// Client supports the follow content formats for the documentation
-        /// property. The order describes the preferred format of the client.
-        /// See `MarkupKind` for common values
-        DocumentationFormat: string[] option
-    }
-
-    type CompletionItemKind =
-    | Text = 1
-    | Method = 2
-    | Function = 3
-    | Constructor = 4
-    | Field = 5
-    | Variable = 6
-    | Class = 7
-    | Interface = 8
-    | Module = 9
-    | Property = 10
-    | Unit = 11
-    | Value = 12
-    | Enum = 13
-    | Keyword = 14
-    | Snippet = 15
-    | Color = 16
-    | File = 17
-    | Reference = 18
-    | Folder = 19
-    | EnumMember = 20
-    | Constant = 21
-    | Struct = 22
-    | Event = 23
-    | Operator = 24
-    | TypeParameter = 25
-
-    type CompletionItemKindCapabilities = {
-        /// The completion item kind values the client supports. When this
-        /// property exists the client also guarantees that it will
-        /// handle values outside its set gracefully and falls back
-        /// to a default value when unknown.
-        ///
-        /// If this property is not present the client only supports
-        /// the completion items kinds from `Text` to `Reference` as defined in
-        /// the initial version of the protocol.
-        ValueSet: CompletionItemKind[] option
-    }
-    with
-        static member DefaultValueSet =
-            [|
-                CompletionItemKind.Text
-                CompletionItemKind.Method
-                CompletionItemKind.Function
-                CompletionItemKind.Constructor
-                CompletionItemKind.Field
-                CompletionItemKind.Variable
-                CompletionItemKind.Class
-                CompletionItemKind.Interface
-                CompletionItemKind.Module
-                CompletionItemKind.Property
-                CompletionItemKind.Unit
-                CompletionItemKind.Value
-                CompletionItemKind.Enum
-                CompletionItemKind.Keyword
-                CompletionItemKind.Snippet
-                CompletionItemKind.Color
-                CompletionItemKind.File
-                CompletionItemKind.Reference
-            |]
-
-    /// Capabilities specific to the `textDocument/completion`
-    type CompletionCapabilities = {
-        /// Whether completion supports dynamic registration.
-        DynamicRegistration: bool option
-
-        /// The client supports the following `CompletionItem` specific
-        /// capabilities.
-        CompletionItem: CompletionItemCapabilities option
-
-        CompletionItemKind: CompletionItemKindCapabilities option
-
-        /// The client supports to send additional context information for a
-        /// `textDocument/completion` request.
-        ContextSupport: bool option
-    }
-
-    type SignatureInformationCapabilities = {
-        /// Client supports the follow content formats for the documentation
-        /// property. The order describes the preferred format of the client.
-        /// See `MarkupKind` for common values
-        DocumentationFormat: string[] option
-    }
-
-    type SignatureHelpCapabilities = {
-        /// Whether signature help supports dynamic registration.
-        DynamicRegistration: bool option
-
-        /// The client supports the following `SignatureInformation`
-        /// specific properties.
-        SignatureInformation: SignatureInformationCapabilities option
-    }
-
-    /// capabilities specific to the `textDocument/documentSymbol`
-    type DocumentSymbolCapabilities = {
-        /// Whether document symbol supports dynamic registration.
-        DynamicRegistration: bool option
-
-        /// Specific capabilities for the `SymbolKind`.
-        SymbolKind: SymbolKindCapabilities option
-        
-        /// The client supports hierarchical document symbols.
-        HierarchicalDocumentSymbolSupport: bool option
-    }
-
-    module CodeActionKind =
-        /// Empty kind.
-        let Empty = ""
-
-        /// Base kind for quickfix actions: 'quickfix'.
-        let QuickFix = "quickfix"
-
-        /// Base kind for refactoring actions: 'refactor'.
-        let Refactor = "refactor"
-
-        /// Base kind for refactoring extraction actions: 'refactor.extract'.
-        ///
-        /// Example extract actions:
-        ///
-        /// - Extract method
-        /// - Extract function
-        /// - Extract variable
-        /// - Extract interface from class
-        /// - ...
-        let RefactorExtract = "refactor.extract"
-
-        /// Base kind for refactoring inline actions: 'refactor.inline'.
-        ///
-        /// Example inline actions:
-        ///
-        /// - Inline function
-        /// - Inline variable
-        /// - Inline constant
-        /// - ...
-        let RefactorInline = "refactor.inline"
-
-        /// Base kind for refactoring rewrite actions: 'refactor.rewrite'.
-        ///
-        /// Example rewrite actions:
-        ///
-        /// - Convert JavaScript function to class
-        /// - Add or remove parameter
-        /// - Encapsulate field
-        /// - Make method static
-        /// - Move method to base class
-        /// - ...
-        let RefactorRewrite = "refactor.rewrite"
-
-        /// Base kind for source actions: `source`.
-        ///
-        /// Source code actions apply to the entire file.
-        let Source = "source"
-
-        ///
-        /// Base kind for an organize imports source action:
-        /// `source.organizeImports`.
-        ///
-        let SourceOrganizeImports = "source.organizeImports"
-
-        ///
-        /// Base kind for a 'fix all' source action: `source.fixAll`.
-        ///
-        /// 'Fix all' actions automatically fix errors that have a clear fix that
-        /// do not require user input. They should not suppress errors or perform
-        /// unsafe fixes such as generating new types or classes.
-        ///
-        /// @since 3.17.0
-        let SourceFixAll = "source.fixAll"
-
-    type CodeActionClientCapabilityLiteralSupportCodeActionKind = {
-        /// The code action kind values the client supports. When this
-        /// property exists the client also guarantees that it will
-        /// handle values outside its set gracefully and falls back
-        /// to a default value when unknown.
-        /// See `CodeActionKind` for common values
-        ValueSet: string[]
-    }
-
-    type CodeActionClientCapabilityLiteralSupport = {
-        /// The code action kind is supported with the following value set.
-        CodeActionKind: CodeActionClientCapabilityLiteralSupportCodeActionKind
-    }
-
-    type CodeActionClientCapabilityResolveSupport = {
-        /// The properties that a client can resolve lazily.
-        Properties: string[]
-    };
-
-    /// capabilities specific to the `textDocument/codeAction`
-    type CodeActionClientCapabilities = {
-        /// Whether document symbol supports dynamic registration.
-        DynamicRegistration: bool option
-
-        /// The client supports code action literals as a valid
-        /// response of the `textDocument/codeAction` request.
-        CodeActionLiteralSupport: CodeActionClientCapabilityLiteralSupport option
-
-        /// Whether code action supports the `isPreferred` property.
-        IsPreferredSupport: bool option
-
-        /// Whether code action supports the `disabled` property.
-        DisabledSupport: bool option
-
-        /// Whether code action supports the `data` property which is
-        /// preserved between a `textDocument/codeAction` and a
-        /// `codeAction/resolve` request.
-        DataSupport: bool option
-
-        /// Whether the client supports resolving additional code action
-        /// properties via a separate `codeAction/resolve` request.
-        ResolveSupport: CodeActionClientCapabilityResolveSupport option
-
-        /// Whether the client honors the change annotations in
-        /// text edits and resource operations returned via the
-        /// `CodeAction#edit` property by for example presenting
-        /// the workspace edit in the user interface and asking
-        /// for confirmation.
-        HonorsChangeAnnotations: bool option
-    }
-
-    [<RequireQualifiedAccess>]
-    type DiagnosticTag =
-        /// Unused or unnecessary code.
-        ///
-        /// Clients are allowed to render diagnostics with this tag faded out instead of having
-        /// an error squiggle.
-        | Unnecessary = 1
-
-    type DiagnosticTagSupport = {
-
-        /// Represents the tags supported by the client
-        ValueSet: DiagnosticTag[]
-    }
-
-    /// Capabilities specific to `textDocument/publishDiagnostics`.
-    type PublishDiagnosticsCapabilites = {
-
-        /// Whether the clients accepts diagnostics with related information.
-        RelatedInformation: bool option
-
-        /// Client supports the tag property to provide meta data about a diagnostic.
-        TagSupport: DiagnosticTagSupport option
-    }
-
-    type FoldingRangeCapabilities =  {
-        /// Whether implementation supports dynamic registration for folding range providers. If this is set to `true`
-        /// the client supports the new `(FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
-        /// return value for the corresponding server capability as well.
-        DynamicRegistration: bool option
-        /// The maximum number of folding ranges that the client prefers to receive per document. The value serves as a
-        /// hint, servers are free to follow the limit.
-        RangeLimit: int option
-        /// If set, the client signals that it only supports folding complete lines. If set, client will
-        /// ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
-        LineFoldingOnly: bool option
-    }
-
-    type SemanticTokenFullRequestType = {
-      /// The client will send the `textDocument/semanticTokens/full/delta`
-      /// request if the server provides a corresponding handler.
-      Delta: bool option
-    }
-
-    type SemanticTokensRequests = {
-        /// The client will send the `textDocument/semanticTokens/range` request
-        /// if the server provides a corresponding handler.
-        Range: U2<bool, obj> option
-
-        /// The client will send the `textDocument/semanticTokens/full` request
-        /// if the server provides a corresponding handler.
-        Full: U2<bool, SemanticTokenFullRequestType> option
-    }
-
-    type TokenFormat =
-    | Relative
-
-    type SemanticTokensClientCapabilities = {
-      /// Whether implementation supports dynamic registration. If this is set to
-      /// `true` the client supports the new `(TextDocumentRegistrationOptions &
-      /// StaticRegistrationOptions)` return value for the corresponding server
-      /// capability as well.
-      DynamicRegistration: bool option
-
-      /// Which requests the client supports and might send to the server
-      /// depending on the server's capability. Please note that clients might not
-      /// show semantic tokens or degrade some of the user experience if a range
-      /// or full request is advertised by the client but not provided by the
-      /// server. If for example the client capability `requests.full` and
-      /// `request.range` are both set to true but the server only provides a
-      /// range provider the client might not render a minimap correctly or might
-      /// even decide to not show any semantic tokens at all.
-      Requests: SemanticTokensRequests
-
-      /// The token types that the client supports.
-      TokenTypes: string[]
-
-      /// The token modifiers that the client supports.
-      TokenModifiers: string[]
-
-      /// The formats the clients supports.
-      Formats: TokenFormat[]
-
-      /// Whether the client supports tokens that can overlap each other.
-      OverlappingTokenSupport: bool option
-
-      /// Whether the client supports tokens that can span multiple lines.
-      MultilineTokenSupport: bool option
-    }
-
-    /// Text document specific client capabilities.
-    type TextDocumentClientCapabilities = {
-        Synchronization: SynchronizationCapabilities option
-
-        /// Capabilities specific to `textDocument/publishDiagnostics`.
-        PublishDiagnostics:PublishDiagnosticsCapabilites
-
-        /// Capabilities specific to the `textDocument/completion`
-        Completion: CompletionCapabilities option
-
-        /// Capabilities specific to the `textDocument/hover`
-        Hover: HoverCapabilities option
-
-        /// Capabilities specific to the `textDocument/signatureHelp`
-        SignatureHelp: SignatureHelpCapabilities option
-
-        /// Capabilities specific to the `textDocument/references`
-        References: DynamicCapabilities option
-
-        /// Whether document highlight supports dynamic registration.
-        DocumentHighlight: DynamicCapabilities option
-
-        /// Capabilities specific to the `textDocument/documentSymbol`
-        DocumentSymbol: DocumentSymbolCapabilities option
-
-        /// Capabilities specific to the `textDocument/formatting`
-        Formatting: DynamicCapabilities option
-
-        /// Capabilities specific to the `textDocument/rangeFormatting`
-        RangeFormatting: DynamicCapabilities option
-
-        /// Capabilities specific to the `textDocument/onTypeFormatting`
-        OnTypeFormatting: DynamicCapabilities option
-
-        /// Capabilities specific to the `textDocument/definition`
-        Definition: DynamicCapabilities option
-
-        /// Capabilities specific to the `textDocument/codeAction`
-        CodeAction: CodeActionClientCapabilities option
-
-        /// Capabilities specific to the `textDocument/codeLens`
-        CodeLens: DynamicCapabilities option
-
-        /// Capabilities specific to the `textDocument/documentLink`
-        DocumentLink: DynamicCapabilities option
-
-        /// Capabilities specific to the `textDocument/rename`
-        Rename: DynamicCapabilities option
-
-        /// Capabilities for the `textDocument/foldingRange`
-        FoldingRange: FoldingRangeCapabilities option
-
-        /// Capabilities for the `textDocument/selectionRange`
-        SelectionRange: DynamicCapabilities option
-
-        /// Capabilities specific to the various semantic token requests.
-        /// @since 3.16.0
-        SemanticTokens: SemanticTokensClientCapabilities option
-    }
-
-    type ClientCapabilities = {
-        /// Workspace specific client capabilities.
-        Workspace: WorkspaceClientCapabilities option
-
-        /// Text document specific client capabilities.
-        TextDocument: TextDocumentClientCapabilities option
-
-        /// Experimental client capabilities.
-        Experimental: JToken option
-    }
-    
-    type WorkspaceFolder = {
-        /// The associated URI for this workspace folder.
-        Uri: DocumentUri;
-
-        /// The name of the workspace folder. Defaults to the
-        /// uri's basename.
-        Name: string;
-    }
-    
-    type ClientInfo = {
-        Name: string
-        Version: string option
-    }
-
-    type InitializeParams = {
-        ProcessId: int option
-        /// Information about the client.
-        /// @since 3.15.0
-        ClientInfo: ClientInfo option
-        RootPath: string option
-        RootUri: string option
-        InitializationOptions: JToken option
-        Capabilities: ClientCapabilities option
-        trace: string option
-        /// The workspace folders configured in the client when the server starts.
-        /// This property is only available if the client supports workspace folders.
-        /// It can be `null` if the client supports workspace folders but none are configured.
-        /// @since 3.6.0
-        WorkspaceFolders: WorkspaceFolder[] option
-    }
-
-    type InitializedParams() =
-        class end
-
-    /// Completion options.
-    type CompletionOptions = {
-        /// The server provides support to resolve additional information for a completion item.
-        ResolveProvider: bool option
-
-        /// The characters that trigger completion automatically.
-        TriggerCharacters: char[] option
-
-        /// The list of all possible characters that commit a completion.
-        /// This field can be used if clients don't support individual commit
-        /// characters per completion item.
-        ///
-        /// See `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`.
-        ///
-        /// If a server provides both `allCommitCharacters` and commit characters
-        /// on an individual completion item, the ones on the completion item win.
-        AllCommitCharacters: char[] option
-    }
-
-    /// Signature help options.
-    type SignatureHelpOptions = {
-        /// The characters that trigger signature help automatically.
-        TriggerCharacters: char[] option
-        /// List of characters that re-trigger signature help.
-        ///
-        /// These trigger characters are only active when signature help is already showing.
-        /// All trigger characters are also counted as re-trigger characters.
-        RetriggerCharacters: char[] option
-    }
-
-    /// Code action options.
-    type CodeActionOptions = {
-        /// CodeActionKinds that this server may return.
-        ///
-        /// The list of kinds may be generic, such as `CodeActionKind.Refactor`,
-        /// or the server may list out every specific kind they provide.
-        CodeActionKinds: string[] option;
-
-        /// The server provides support to resolve additional
-        /// information for a code action.
-        ResolveProvider: bool option;
-    }
-
-    /// Code Lens options.
-    type CodeLensOptions = {
-        /// Code lens has a resolve provider as well.
-        ResolveProvider: bool option
-    }
-
-    /// Format document on type options
-    type DocumentOnTypeFormattingOptions = {
-        /// A character on which formatting should be triggered, like `}`.
-        FirstTriggerCharacter: char
-
-        /// More trigger characters.
-        MoreTriggerCharacter: char[] option
-    }
-
-    /// Document link options
-    type DocumentLinkOptions = {
-        /// Document links have a resolve provider as well.
-        ResolveProvider: bool option
-    }
-
-    /// Execute command options.
-    type ExecuteCommandOptions = {
-        /// The commands to be executed on the server
-        commands: string[] option
-    }
-
-    /// Save options.
-    type SaveOptions = {
-        /// The client is supposed to include the content on save.
-        IncludeText: bool option
-    }
-
-    type TextDocumentSyncOptions = {
-        /// Open and close notifications are sent to the server.
-        OpenClose: bool option
-
-        /// Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
-        /// and TextDocumentSyncKind.Incremental.
-        Change: TextDocumentSyncKind option
-
-        /// Will save notifications are sent to the server.
-        WillSave: bool option
-
-        /// Will save wait until requests are sent to the server.
-        WillSaveWaitUntil: bool option
-
-        /// Save notifications are sent to the server.
-        Save: SaveOptions option
-    }
-    with
-        static member Default =
-            {
-                OpenClose = None
-                Change = None
-                WillSave = None
-                WillSaveWaitUntil = None
-                Save = None
-            }
-
-    type SemanticTokensLegend = {
-      /// The token types a server uses.
-      TokenTypes: string[]
-      /// The token modifiers a server uses.
-      TokenModifiers: string[]
-    }
-
-    type SemanticTokenFullOptions =
-      {
-        /// The server supports deltas for full documents.
-        Delta: bool option
-      }
-    type SemanticTokensOptions = {
-      /// The legend used by the server
-      Legend: SemanticTokensLegend
-
-      /// Server supports providing semantic tokens for a specific range of a document.
-      Range: U2<bool, obj> option
-
-      /// Server supports providing semantic tokens for a full document.
-      Full: U2<bool, SemanticTokenFullOptions> option
-    }
-    
-    type WorkspaceFoldersServerCapabilities = {
-        /// The server has support for workspace folders.
-        Supported: bool option
-        /// Whether the server wants to receive workspace folder change notifications.
-        /// NOTE: the spec allows a string value here too. Good opportunity for further modeling.
-        ChangeNotifications: bool option
-    }
-    with
-        static member Default =
-            {
-                Supported = None
-                ChangeNotifications = None
-            }
-    
-    module FileOperationPatternKind =
-        let File = "file"
-        let Folder = "folder"
-    
-    type FileOperationPatternOptions = {
-        /// The pattern should be matched ignoring casing.
-        IgnoreCase: bool option
-    }
-    with
-        static member Default =
-            { IgnoreCase = None }
-    
-    /// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileOperationPattern.
-    type FileOperationPattern = {
-        Glob: string
-        /// Whether to match files or folders with this pattern. Matches both if undefined.
-        /// See FileOperationPatternKind for allowed values
-        Matches: string option
-        /// Additional options used during matching
-        Options: FileOperationPatternOptions option
-    }
-    
-    type FileOperationFilter = {
-        /// A Uri like `file` or `untitled`.
-        Scheme: string option
-        /// The actual file operation pattern.
-        Pattern: FileOperationPattern
+  /// Notifications don't generate a response or error, but to unify things we consider them as always successful.
+  /// They will still not send any response because their ID is null.
+  let private notificationSuccess (response: Async<unit>) =
+    async {
+      do! response
+      return Result.Ok()
     }
-    
-    type FileOperationRegistrationOptions = {
-        Filters: FileOperationFilter[]
-    }
-    
-    /// The types of workspace-level file notifications the server is interested in.
-    type WorkspaceFileOperationsServerCapabilities = {
-        DidCreate: FileOperationRegistrationOptions option
-        WillCreate: FileOperationRegistrationOptions option
-        DidRename: FileOperationRegistrationOptions option
-        WillRename: FileOperationRegistrationOptions option
-        DidDelete: FileOperationRegistrationOptions option
-        WillDelete: FileOperationRegistrationOptions option
-    }
-    with
-        static member Default =
-            {
-                DidCreate = None
-                WillCreate = None
-                DidRename = None
-                WillRename = None
-                DidDelete = None
-                WillDelete = None
-            }
-    
-    type WorkspaceServerCapabilities = {
-        /// The server supports workspace folder.
-        /// @since 3.6.0
-        WorkspaceFolders: WorkspaceFoldersServerCapabilities option
-        /// The server is interested in file notifications/requests.
-        /// @since 3.16.0
-        FileOperations: WorkspaceFileOperationsServerCapabilities option
-    }
-    with
-        static member Default =
-            {
-                WorkspaceFolders = None
-                FileOperations = None
-            }
-
-    type ServerCapabilities = {
-        /// Defines how text documents are synced. Is either a detailed structure defining each notification or
-        /// for backwards compatibility the TextDocumentSyncKind number.
-        TextDocumentSync: TextDocumentSyncOptions option
-
-        /// The server provides hover support.
-        HoverProvider: bool option
-
-        /// The server provides completion support.
-        CompletionProvider: CompletionOptions option
-
-        /// The server provides signature help support.
-        SignatureHelpProvider: SignatureHelpOptions option
-
-        /// The server provides goto definition support.
-        DefinitionProvider: bool option
-
-        ///The server provides Goto Implementation support
-        ImplementationProvider :bool option
-
-        /// The server provides goto type definition support.
-        TypeDefinitionProvider: bool option
-
-        /// The server provides find references support.
-        ReferencesProvider: bool option
-
-        /// The server provides document highlight support.
-        DocumentHighlightProvider: bool option
-
-        /// The server provides document symbol support.
-        DocumentSymbolProvider: bool option
-
-        /// The server provides workspace symbol support.
-        WorkspaceSymbolProvider: bool option
-
-        /// The server provides code actions.
-        CodeActionProvider: CodeActionOptions option
-
-        /// The server provides code lens.
-        CodeLensProvider: CodeLensOptions option
-
-        /// The server provides document formatting.
-        DocumentFormattingProvider: bool option
-
-        /// The server provides document range formatting.
-        DocumentRangeFormattingProvider: bool option
-
-        /// The server provides document formatting on typing.
-        DocumentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions option
-
-        /// The server provides rename support.
-        RenameProvider: bool option
-
-        /// The server provides document link support.
-        DocumentLinkProvider: DocumentLinkOptions option
-
-        /// The server provides execute command support.
-        ExecuteCommandProvider: ExecuteCommandOptions option
-
-        /// Experimental server capabilities.
-        Experimental: JToken option
-
-        /// The server provides folding provider support.
-        /// @since 3.10.0
-        FoldingRangeProvider: bool option
-
-        SelectionRangeProvider: bool option
-
-        SemanticTokensProvider: SemanticTokensOptions option
-        
-        /// Workspace specific server capabilities.
-        Workspace: WorkspaceServerCapabilities option
-
-    }
-    with
-        static member Default =
-            {
-                HoverProvider = None
-                TextDocumentSync = None
-                CompletionProvider = None
-                SignatureHelpProvider = None
-                DefinitionProvider = None
-                TypeDefinitionProvider = None
-                ImplementationProvider = None
-                ReferencesProvider = None
-                DocumentHighlightProvider = None
-                DocumentSymbolProvider = None
-                WorkspaceSymbolProvider = None
-                CodeActionProvider = None
-                CodeLensProvider = None
-                DocumentFormattingProvider = None
-                DocumentRangeFormattingProvider = None
-                DocumentOnTypeFormattingProvider = None
-                RenameProvider = None
-                DocumentLinkProvider = None
-                ExecuteCommandProvider = None
-                Experimental = None
-                FoldingRangeProvider = None
-                SelectionRangeProvider = None
-                SemanticTokensProvider = None
-                Workspace = None
-            }
-
-    type InitializeResult = {
-        Capabilities: ServerCapabilities
-    }
-    with
-        static member Default =
-            {
-                Capabilities = ServerCapabilities.Default
-            }
-
-    /// A workspace edit represents changes to many resources managed in the workspace.
-    /// The edit should either provide `changes` or `documentChanges`. If the client can handle versioned document
-    /// edits and if `documentChanges` are present, the latter are preferred over `changes`.
-    type WorkspaceEdit = {
-        /// Holds changes to existing resources.
-        Changes: Map<string, TextEdit[]> option
-
-        /// An array of `TextDocumentEdit`s to express changes to n different text documents
-        /// where each text document edit addresses a specific version of a text document.
-        /// Whether a client supports versioned document edits is expressed via
-        /// `WorkspaceClientCapabilities.workspaceEdit.documentChanges`.
-        DocumentChanges: TextDocumentEdit[] option
-    }
-    with
-        static member DocumentChangesToChanges(edits: TextDocumentEdit[]) =
-            edits
-            |> Array.map (fun edit -> edit.TextDocument.Uri.ToString(), edit.Edits)
-            |> Map.ofArray
-
-        static member CanUseDocumentChanges(capabilities: ClientCapabilities) =
-            (capabilities.Workspace
-            |> Option.bind(fun x -> x.WorkspaceEdit)
-            |> Option.bind (fun x -> x.DocumentChanges))
-                = Some true
-
-        static member Create(edits: TextDocumentEdit[], capabilities: ClientCapabilities ) =
-            if WorkspaceEdit.CanUseDocumentChanges(capabilities) then
-                {
-                    Changes = None
-                    DocumentChanges = Some edits
-                }
-            else
-                {
-                    Changes = Some (WorkspaceEdit.DocumentChangesToChanges edits)
-                    DocumentChanges = None
-                }
-
-    type MessageType =
-        | Error = 1
-        | Warning = 2
-        | Info = 3
-        | Log = 4
-
-    type LogMessageParams = {
-        Type: MessageType
-        Message: string
-    }
-
-    type ShowMessageParams = {
-        Type: MessageType
-        Message: string
-    }
-
-    type MessageActionItem = {
-        /// A short title like 'Retry', 'Open Log' etc.
-        Title: string;
-    }
-
-    type ShowMessageRequestParams = {
-        /// The message type.
-        Type: MessageType
-
-        /// The actual message
-        Message: string
-
-        /// The message action items to present.
-        Actions: MessageActionItem[] option
-    }
-
-    /// General parameters to register for a capability.
-    type Registration = {
-        /// The id used to register the request. The id can be used to deregister
-        /// the request again.
-        Id: string
-
-        /// The method / capability to register for.
-        Method: string
-
-        /// Options necessary for the registration.
-        RegisterOptions: JToken option
-    }
-
-    type RegistrationParams = {
-        Registrations: Registration[]
-    }
-
-    type ITextDocumentRegistrationOptions =
-        /// A document selector to identify the scope of the registration. If set to null
-        /// the document selector provided on the client side will be used.
-        abstract member DocumentSelector : DocumentSelector option with get
-
-    /// General parameters to unregister a capability.
-    type Unregistration = {
-        /// The id used to unregister the request or notification. Usually an id
-        /// provided during the register request.
-        Id: string
-
-        /// The method / capability to unregister for.
-        Method: string
-    }
-
-    type UnregistrationParams = {
-        Unregisterations: Unregistration[]
-    }
-
-    type FileChangeType =
-        | Created = 1
-        | Changed = 2
-        | Deleted = 3
-
-    /// An event describing a file change.
-    type FileEvent ={
-        /// The file's URI.
-        Uri: DocumentUri
-
-        /// The change type.
-        Type: FileChangeType
-    }
-
-    type DidChangeWatchedFilesParams = {
-        /// The actual file events.
-        Changes: FileEvent[]
-    }
-
-    /// The workspace folder change event.
-    type WorkspaceFoldersChangeEvent = {
-        /// The array of added workspace folders
-        Added: WorkspaceFolder[];
-
-        /// The array of the removed workspace folders
-        Removed: WorkspaceFolder[];
-    }
-
-    type DidChangeWorkspaceFoldersParams = {
-        /// The actual workspace folder change event.
-        Event: WorkspaceFoldersChangeEvent
-    }
-
-    type DidChangeConfigurationParams = {
-        /// The actual changed settings
-        Settings: JToken;
-    }
-
-    type ConfigurationItem = {
-        /// The scope to get the configuration section for.
-        ScopeUri: string option
-
-        /// The configuration section asked for.
-        Section: string option
-    }
-
-    type ConfigurationParams = {
-        items: ConfigurationItem[]
-    }
-
-    /// The parameters of a Workspace Symbol Request.
-    type WorkspaceSymbolParams = {
-        /// A non-empty query string
-        Query: string
-    }
-
-    type ExecuteCommandParams = {
-        /// The identifier of the actual command handler.
-        Command: string
-        /// Arguments that the command should be invoked with.
-        Arguments: JToken[] option
-    }
-
-    type ApplyWorkspaceEditParams = {
-        /// An optional label of the workspace edit. This label is
-        /// presented in the user interface for example on an undo
-        /// stack to undo the workspace edit.
-        Label: string option
-
-        /// The edits to apply.
-        Edit: WorkspaceEdit
-    }
-
-    type ApplyWorkspaceEditResponse = {
-        /// Indicates whether the edit was applied or not.
-        Applied: bool
-    }
-
-    /// Represents reasons why a text document is saved.
-    type TextDocumentSaveReason =
-        /// Manually triggered, e.g. by the user pressing save, by starting debugging,
-        /// or by an API call.
-        | Manual = 1
-
-        /// Automatic after a delay.
-        | AfterDelay = 2
-
-        /// When the editor lost focus.
-        | FocusOut = 3
 
-    /// The parameters send in a will save text document notification.
-    type WillSaveTextDocumentParams = {
-        /// The document that will be saved.
-        TextDocument: TextDocumentIdentifier
+  type ClientNotificationSender = string -> obj -> AsyncLspResult<unit>
 
-        /// The 'TextDocumentSaveReason'.
-        Reason: TextDocumentSaveReason
-    }
-
-    type DidSaveTextDocumentParams = {
-        /// The document that was saved.
-        TextDocument: TextDocumentIdentifier
-
-        /// Optional the content when saved. Depends on the includeText value
-        /// when the save notification was requested.
-        Text: string option
-    }
-
-    type DidCloseTextDocumentParams = {
-        /// The document that was closed.
-        TextDocument: TextDocumentIdentifier
-    }
-
-    /// Value-object describing what options formatting should use.
-    type FormattingOptions() =
-        /// Size of a tab in spaces.
-        member val TabSize : int = 0 with get, set
-
-        /// Prefer spaces over tabs.
-        member val InsertSpaces: bool = false with get, set
-
-        /// Further properties.
-        [<JsonExtensionData>]
-        member val AdditionalData: System.Collections.Generic.IDictionary<string, JToken> = new System.Collections.Generic.Dictionary<_,_>() :> _ with get, set
-
-    type DocumentFormattingParams = {
-        /// The document to format.
-        TextDocument: TextDocumentIdentifier
-
-        /// The format options.
-        Options: FormattingOptions
-    }
-
-    type DocumentRangeFormattingParams = {
-        /// The document to format.
-        TextDocument: TextDocumentIdentifier
-
-        /// The range to format
-        Range: Range
-
-        /// The format options
-        Options: FormattingOptions
-    }
-
-    type DocumentOnTypeFormattingParams = {
-        /// The document to format.
-        TextDocument: TextDocumentIdentifier
-
-        /// The position at which this request was sent.
-        Position: Position
-
-        /// The character that has been typed.
-        Ch: char
-
-        /// The format options.
-        Options: FormattingOptions
-    }
-
-    type DocumentSymbolParams = {
-        /// The text document.
-        TextDocument: TextDocumentIdentifier
-    }
-
-    type ITextDocumentPositionParams =
-        /// The text document.
-        abstract member TextDocument : TextDocumentIdentifier with get
-        /// The position inside the text document.
-        abstract member Position : Position with get
-
-    type TextDocumentPositionParams =
-        {
-            /// The text document.
-            TextDocument: TextDocumentIdentifier
-            /// The position inside the text document.
-            Position: Position
-        }
-        interface ITextDocumentPositionParams with
-            member this.TextDocument with get() = this.TextDocument
-            member this.Position with get() = this.Position
-
-    type ReferenceContext = {
-        /// Include the declaration of the current symbol.
-        IncludeDeclaration: bool
-    }
-
-    type ReferenceParams  =
-        {
-            /// The text document.
-            TextDocument: TextDocumentIdentifier
-            /// The position inside the text document.
-            Position: Position
-            Context: ReferenceContext
-        }
-        interface ITextDocumentPositionParams with
-            member this.TextDocument with get() = this.TextDocument
-            member this.Position with get() = this.Position
-
-    /// A `MarkupContent` literal represents a string value which content is interpreted base on its
-    /// kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
-    ///
-    /// If the kind is `markdown` then the value can contain fenced code blocks like in GitHub issues.
-    /// See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
-    ///
-    /// Here is an example how such a string can be constructed using JavaScript / TypeScript:
-    /// ```ts
-    /// let markdown: MarkdownContent = {
-    ///     kind: MarkupKind.Markdown,
-    ///     value: [
-    ///         '# Header',
-    ///         'Some text',
-    ///         '```typescript',
-    ///         'someCode();',
-    ///         '```'
-    ///     ].join('\n')
-    /// };
-    /// ```
-    ///
-    /// *Please Note* that clients might sanitize the return markdown. A client could decide to
-    /// remove HTML from the markdown to avoid script execution.
-    type MarkupContent = {
-        /// The type of the Markup
-        Kind: string
-
-        // The content itself
-        Value: string
-    }
-
-    type MarkedStringData = {
-        Language: string
-        Value: string
-    }
-
-    [<ErasedUnion>]
-    [<RequireQualifiedAccess>]
-    type MarkedString =
-    | String of string
-    | WithLanguage of MarkedStringData
-
-    let plaintext s = { Kind = MarkupKind.PlainText; Value = s }
-    let markdown s = { Kind = MarkupKind.Markdown; Value = s }
-
-    [<ErasedUnion>]
-    type HoverContent =
-        | MarkedString of MarkedString
-        | MarkedStrings of MarkedString []
-        | MarkupContent of MarkupContent
-
-    /// The result of a hover request.
-    type Hover = {
-        /// The hover's content
-        Contents: HoverContent
-
-        /// An optional range is a range inside a text document
-        /// that is used to visualize a hover, e.g. by changing the background color.
-        Range: Range option
-    }
-
-    /// An item to transfer a text document from the client to the server.
-    type TextDocumentItem = {
-        /// The text document's URI.
-        Uri: DocumentUri
-
-        /// The text document's language identifier.
-        LanguageId: string
-
-        /// The version number of this document (it will increase after each
-        /// change, including undo/redo).
-        Version: int
-
-        /// The content of the opened text document.
-        Text: string
-    }
+  type ClientRequestSender =
+    abstract member Send<'a> : string -> obj -> AsyncLspResult<'a>
 
-    type DidOpenTextDocumentParams = {
-        /// The document that was opened.
-        TextDocument: TextDocumentItem
-    }
-
-    /// An event describing a change to a text document. If range and rangeLength are omitted
-    /// the new text is considered to be the full content of the document.
-    type TextDocumentContentChangeEvent = {
-        /// The range of the document that changed.
-        Range: Range option
-
-        /// The length of the range that got replaced.
-        RangeLength: int option
-
-        /// The new text of the range/document.
-        Text: string
-    }
-
-    type DidChangeTextDocumentParams = {
-        /// The document that did change. The version number points
-        /// to the version after all provided content changes have
-        /// been applied.
-        TextDocument: VersionedTextDocumentIdentifier
-
-        /// The actual content changes. The content changes describe single state changes
-        /// to the document. So if there are two content changes c1 and c2 for a document
-        /// in state S10 then c1 move the document to S11 and c2 to S12.
-        ContentChanges: TextDocumentContentChangeEvent[]
-    }
-
-    [<Flags>]
-    type WatchKind =
-        | Create = 1
-        | Change = 2
-        | Delete = 4
-
-    type FileSystemWatcher = {
-        /// The  glob pattern to watch
-        GlobPattern: string
-
-        /// The kind of events of interest. If omitted it defaults
-        /// to WatchKind.Create | WatchKind.Change | WatchKind.Delete
-        /// which is 7.
-        Kind: WatchKind option
-    }
-
-    /// Describe options to be used when registered for text document change events.
-    type DidChangeWatchedFilesRegistrationOptions = {
-        /// The watchers to register.
-        Watchers: FileSystemWatcher[]
-    }
-
-    /// How a completion was triggered
-    type CompletionTriggerKind =
-        /// Completion was triggered by typing an identifier (24x7 code
-        /// complete), manual invocation (e.g Ctrl+Space) or via API.
-        | Invoked = 1
-        /// Completion was triggered by a trigger character specified by
-        /// the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
-        | TriggerCharacter = 2
-
-    type CompletionContext = {
-        ///  How the completion was triggered.
-        triggerKind: CompletionTriggerKind
-
-        /// The trigger character (a single character) that has trigger code complete.
-        /// Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
-        triggerCharacter: char option
-    }
-
-    type CompletionParams =
-        {
-            /// The text document.
-            TextDocument: TextDocumentIdentifier
-
-            /// The position inside the text document.
-            Position: Position
-
-            /// The completion context. This is only available it the client specifies
-            /// to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
-            Context: CompletionContext option
-        }
-        interface ITextDocumentPositionParams with
-            member this.TextDocument with get() = this.TextDocument
-            member this.Position with get() = this.Position
-
-    /// Represents a reference to a command. Provides a title which will be used to represent a command in the UI.
-    /// Commands are identified by a string identifier. The protocol currently doesn't specify a set of well-known
-    /// commands. So executing a command requires some tool extension code.
-    type Command = {
-        /// Title of the command, like `save`.
-        Title: string
+  type private MessageHandlingResult =
+    | Normal
+    | WasExit
+    | WasShutdown
 
-        /// The identifier of the actual command handler.
-        Command: string
+  type LspCloseReason =
+    | RequestedByClient = 0
+    | ErrorExitWithoutShutdown = 1
+    | ErrorStreamClosed = 2
 
-        /// Arguments that the command handler should be
-        /// invoked with.
-        Arguments: JToken[] option
-    }
-
-    /// Defines whether the insert text in a completion item should be interpreted as
-    /// plain text or a snippet.
-    type InsertTextFormat =
-        /// The primary text to be inserted is treated as a plain string.
-        | PlainText = 1
-        /// The primary text to be inserted is treated as a snippet.
-        ///
-        /// A snippet can define tab stops and placeholders with `$1`, `$2`
-        /// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
-        /// the end of the snippet. Placeholders with equal identifiers are linked,
-        /// that is typing in one will update others too.
-        | Snippet = 2
-
-    [<ErasedUnion>]
-    [<RequireQualifiedAccess>]
-    type Documentation =
-    | String of string
-    | Markup of MarkupContent
-
-    type CompletionItem = {
-        /// The label of this completion item. By default
-        /// also the text that is inserted when selecting
-        /// this completion.
-        Label: string
-
-        /// The kind of this completion item. Based of the kind
-        /// an icon is chosen by the editor.
-        Kind: CompletionItemKind option
-
-        /// A human-readable string with additional information
-        /// about this item, like type or symbol information.
-        Detail: string option
-
-        /// A human-readable string that represents a doc-comment.
-        Documentation: Documentation option
-
-        /// A string that should be used when comparing this item
-        /// with other items. When `falsy` the label is used.
-        SortText: string option
-
-        /// A string that should be used when filtering a set of
-        /// completion items. When `falsy` the label is used.
-        FilterText: string option
-
-        /// A string that should be inserted into a document when selecting
-        /// this completion. When `falsy` the label is used.
-        ///
-        /// The `insertText` is subject to interpretation by the client side.
-        /// Some tools might not take the string literally. For example
-        /// VS Code when code complete is requested in this example `con<cursor position>`
-        /// and a completion item with an `insertText` of `console` is provided it
-        /// will only insert `sole`. Therefore it is recommended to use `textEdit` instead
-        /// since it avoids additional client side interpretation.
-        ///
-        /// @deprecated Use textEdit instead.
-        InsertText: string option
-
-        /// The format of the insert text. The format applies to both the `insertText` property
-        /// and the `newText` property of a provided `textEdit`.
-        InsertTextFormat: InsertTextFormat option
+  let startWithSetup<'client when 'client :> Ionide.LanguageServerProtocol.LspClient>
+    (setupRequestHandlings: 'client -> Map<string, Delegate>)
+    (input: Stream)
+    (output: Stream)
+    (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client)
+    =
 
-        /// An edit which is applied to a document when selecting this completion. When an edit is provided the value of
-        /// `insertText` is ignored.
-        ///
-        /// *Note:* The range of the edit must be a single line range and it must contain the position at which completion
-        /// has been requested.
-        TextEdit: TextEdit option
+    use jsonRpcHandler = new HeaderDelimitedMessageHandler(output, input, jsonRpcFormatter)
+    use jsonRpc = new JsonRpc(jsonRpcHandler)
 
-        /// An optional array of additional text edits that are applied when
-        /// selecting this completion. Edits must not overlap with the main edit
-        /// nor with themselves.
-        AdditionalTextEdits: TextEdit[] option
-
-        /// An optional set of characters that when pressed while this completion is active will accept it first and
-        /// then type that character. *Note* that all commit characters should have `length=1` and that superfluous
-        /// characters will be ignored.
-        CommitCharacters: char[] option
-
-        /// An optional command that is executed *after* inserting this completion. *Note* that
-        /// additional modifications to the current document should be described with the
-        /// additionalTextEdits-property.
-        Command: Command option
-
-        /// An data entry field that is preserved on a completion item between
-        /// a completion and a completion resolve request.
-        Data: JToken option
-    }
-    with
-        static member Create(label:string) =
-            {
-                Label = label
-                Kind = None
-                Detail = None
-                Documentation = None
-                SortText = None
-                FilterText = None
-                InsertText = None
-                InsertTextFormat = None
-                TextEdit = None
-                AdditionalTextEdits = None
-                CommitCharacters = None
-                Command = None
-                Data = None
-            }
-
-    type CompletionList = {
-        /// This list it not complete. Further typing should result in recomputing
-        /// this list.
-        IsIncomplete: bool
-
-        /// The completion items.
-        Items: CompletionItem[]
-    }
-
-    [<ErasedUnion>]
-    [<RequireQualifiedAccess>]
-    type DiagnosticCode =
-    | Number of int
-    | String of string
-
-    [<RequireQualifiedAccess>]
-    type DiagnosticSeverity =
-        ///  Reports an error.
-        | Error = 1
-        ///  Reports a warning.
-        | Warning = 2
-        ///  Reports an information.
-        | Information = 3
-        ///  Reports a hint.
-        | Hint = 4
-
-    /// Represents a related message and source code location for a diagnostic. This should be
-    /// used to point to code locations that cause or related to a diagnostics, e.g when duplicating
-    /// a symbol in a scope.
-    type DiagnosticRelatedInformation = {
-        Location: Location
-        Message: string
-    }
+    /// When the server wants to send a notification to the client
+    let sendServerNotification (rpcMethod: string) (notificationObj: obj) : AsyncLspResult<unit> =
+      async {
+        do!
+          jsonRpc.NotifyWithParameterObjectAsync(rpcMethod, notificationObj)
+          |> Async.AwaitTask
 
-    // Structure to capture a description for an error code.
-    type CodeDescription =
-      {
-        // An URI to open with more information about the diagnostic error.
-        Href: Uri option
+        return () |> LspResult.success
       }
 
-    /// Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid in the
-    /// scope of a resource.
-    [<DebuggerDisplay("{DebuggerDisplay}")>]
-    type Diagnostic =
-      {
-          /// The range at which the message applies.
-          Range: Range
+    /// When the server wants to send a request to the client
+    let sendServerRequest (rpcMethod: string) (requestObj: obj) : AsyncLspResult<'response> =
+      async {
+        let! response =
+          jsonRpc.InvokeWithParameterObjectAsync<'response>(rpcMethod, requestObj)
+          |> Async.AwaitTask
 
-          /// The diagnostic's severity. Can be omitted. If omitted it is up to the
-          /// client to interpret diagnostics as error, warning, info or hint.
-          Severity: DiagnosticSeverity option
-
-          /// The diagnostic's code. Can be omitted.
-          Code: string option
-          /// An optional property to describe the error code.
-          CodeDescription: CodeDescription option
-
-          /// A human-readable string describing the source of this
-          /// diagnostic, e.g. 'typescript' or 'super lint'.
-          Source: string
-
-          /// The diagnostic's message.
-          Message: string
-          RelatedInformation: DiagnosticRelatedInformation [] option
-          Tags: DiagnosticTag[] option
-          /// A data entry field that is preserved between a
-          /// `textDocument/publishDiagnostics` notification and
-          /// `textDocument/codeAction` request.
-          Data: obj option
-
-      }
-      [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
-      member x.DebuggerDisplay = $"[{defaultArg x.Severity DiagnosticSeverity.Error}] ({x.Range.DebuggerDisplay}) {x.Message} ({defaultArg x.Code String.Empty})"
-
-    type PublishDiagnosticsParams = {
-        /// The URI for which diagnostic information is reported.
-        Uri: DocumentUri
-
-        /// An array of diagnostic information items.
-        Diagnostics: Diagnostic[]
-    }
-
-    type CodeActionDisabled = {
-        /// Human readable description of why the code action is currently
-        /// disabled.
-        ///
-        /// This is displayed in the code actions UI.
-        Reason: string
-    }
-
-    /// A code action represents a change that can be performed in code, e.g. to fix a problem or
-    /// to refactor code.
-    ///
-    /// A CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed.
-    type CodeAction = {
-
-        /// A short, human-readable, title for this code action.
-        Title: string
-
-        /// The kind of the code action.
-        /// Used to filter code actions.
-        Kind: string option
-
-        /// The diagnostics that this code action resolves.
-        Diagnostics: Diagnostic[] option
-
-        /// Marks this as a preferred action. Preferred actions are used by the
-        /// `auto fix` command and can be targeted by keybindings.
-        ///
-        /// * A quick fix should be marked preferred if it properly addresses the
-        /// underlying error. A refactoring should be marked preferred if it is the
-        /// most reasonable choice of actions to take.
-        ///
-        /// * @since 3.15.0
-        IsPreferred: bool option
-
-        /// Marks that the code action cannot currently be applied.
-        ///
-        /// Clients should follow the following guidelines regarding disabled code
-        /// actions:
-        ///
-        /// - Disabled code actions are not shown in automatic lightbulbs code
-        /// action menus.
-        ///
-        /// - Disabled actions are shown as faded out in the code action menu when
-        /// the user request a more specific type of code action, such as
-        /// refactorings.
-        ///
-        /// - If the user has a keybinding that auto applies a code action and only
-        /// a disabled code actions are returned, the client should show the user
-        /// an error message with `reason` in the editor.
-        ///
-        /// @since 3.16.0
-        Disabled: CodeActionDisabled option
-
-        /// The workspace edit this code action performs.
-        Edit: WorkspaceEdit option
-
-        /// A command this code action executes. If a code action
-        /// provides an edit and a command, first the edit is
-        /// executed and then the command.
-        Command: Command option
-
-        /// A data entry field that is preserved on a code action between
-        /// a `textDocument/codeAction` and a `codeAction/resolve` request.
-        Data: obj option
-    }
-
-    [<ErasedUnion>]
-    [<RequireQualifiedAccess>]
-    type TextDocumentCodeActionResult =
-    | Commands of Command []
-    | CodeActions of CodeAction []
-
-    type RenameParams =
-        {
-            /// The document to rename.
-            TextDocument: TextDocumentIdentifier
-
-            /// The position at which this request was sent.
-            Position: Position
-
-            /// The new name of the symbol. If the given name is not valid the
-            /// request must return a **ResponseError** with an
-            /// appropriate message set.
-            NewName: string
-        }
-        interface ITextDocumentPositionParams with
-            member this.TextDocument with get() = this.TextDocument
-            member this.Position with get() = this.Position
-
-    [<ErasedUnion>]
-    [<RequireQualifiedAccess>]
-    type GotoResult =
-    | Single of Location
-    | Multiple of Location []
-
-    /// A document highlight kind.
-    [<RequireQualifiedAccess>]
-    type DocumentHighlightKind =
-        /// A textual occurrence.
-        | Text = 1
-
-        /// Read-access of a symbol, like reading a variable.
-        | Read = 2
-
-        /// Write-access of a symbol, like writing to a variable.
-        | Write = 3
-
-    /// A document highlight is a range inside a text document which deserves
-    /// special attention. Usually a document highlight is visualized by changing
-    /// the background color of its range.
-    type DocumentHighlight = {
-        /// The range this highlight applies to.
-        Range: Range
-
-        /// The highlight kind, default is DocumentHighlightKind.Text.
-        Kind: DocumentHighlightKind option
-    }
-
-    type DocumentLinkParams = {
-        /// The document to provide document links for.
-        TextDocument: TextDocumentIdentifier
-    }
-
-    /// A document link is a range in a text document that links to an internal or external resource, like another
-    /// text document or a web site.
-    type DocumentLink = {
-        /// The range this link applies to.
-        Range: Range
-
-        /// The uri this link points to. If missing a resolve request is sent later.
-        Target: DocumentUri option
-    }
-
-    type DocumentColorParams = {
-        /// The text document.
-        TextDocument: TextDocumentIdentifier
-    }
-
-    /// Represents a color in RGBA space.
-    type Color = {
-        /// The red component of this color in the range [0-1].
-        Red: float
-
-        /// The green component of this color in the range [0-1].
-        Green: float
-
-        /// The blue component of this color in the range [0-1].
-        Blue: float
-
-        /// The alpha component of this color in the range [0-1].
-        Alpha: float
-    }
-
-    type ColorInformation = {
-        /// The range in the document where this color appears.
-        Range: Range
-
-        /// The actual color value for this color range.
-        Color: Color
-    }
-
-    type ColorPresentationParams = {
-        /// The text document.
-        TextDocument: TextDocumentIdentifier
-
-        /// The color information to request presentations for.
-        ColorInfo: Color
-
-        /// The range where the color would be inserted. Serves as a context.
-        Range: Range
-    }
-
-    type ColorPresentation = {
-        /// The label of this color presentation. It will be shown on the color
-        /// picker header. By default this is also the text that is inserted when selecting
-        /// this color presentation.
-        Label: string
-
-        /// An edit which is applied to a document when selecting
-        /// this presentation for the color.  When `falsy` the label
-        /// is used.
-        TextEdit: TextEdit option
-
-        /// An optional array of additional text edits that are applied when
-        /// selecting this color presentation. Edits must not overlap with the main edit nor with themselves.
-        AdditionalTextEdits: TextEdit[] option
-    }
-
-    /// Contains additional diagnostic information about the context in which
-    /// a code action is run.
-    type CodeActionContext = {
-        /// An array of diagnostics.
-        Diagnostics: Diagnostic[]
-    }
-
-    /// Params for the CodeActionRequest
-    type CodeActionParams = {
-        /// The document in which the command was invoked.
-        TextDocument: TextDocumentIdentifier
-
-        /// The range for which the command was invoked.
-        Range: Range
-
-        /// Context carrying additional information.
-        Context: CodeActionContext
-    }
-
-    type CodeLensParams = {
-        /// The document to request code lens for.
-        TextDocument: TextDocumentIdentifier;
-    }
-
-    /// A code lens represents a command that should be shown along with
-    /// source text, like the number of references, a way to run tests, etc.
-    ///
-    /// A code lens is _unresolved_ when no command is associated to it. For performance
-    /// reasons the creation of a code lens and resolving should be done in two stages.
-    type CodeLens = {
-        /// The range in which this code lens is valid. Should only span a single line.
-        Range: Range
-
-        /// The command this code lens represents.
-        Command: Command option
-
-        /// A data entry field that is preserved on a code lens item between
-        /// a code lens and a code lens resolve request.
-        Data: JToken option
-    }
-
-    /// Represents a parameter of a callable-signature. A parameter can
-    /// have a label and a doc-comment.
-    type ParameterInformation = {
-        /// The label of this parameter. Will be shown in
-        /// the UI.
-        Label: string
-
-        /// The human-readable doc-comment of this parameter. Will be shown
-        /// in the UI but can be omitted.
-        Documentation: Documentation option
-    }
-
-    ///Represents the signature of something callable. A signature
-    /// can have a label, like a function-name, a doc-comment, and
-    /// a set of parameters.
-    type SignatureInformation = {
-        /// The label of this signature. Will be shown in
-        /// the UI.
-        Label: string
-
-        /// The human-readable doc-comment of this signature. Will be shown
-        /// in the UI but can be omitted.
-        Documentation: Documentation option
-
-        /// The parameters of this signature.
-        Parameters: ParameterInformation[] option
-    }
-
-    /// Signature help represents the signature of something
-    /// callable. There can be multiple signature but only one
-    /// active and only one active parameter.
-    type SignatureHelp = {
-        /// One or more signatures.
-        Signatures: SignatureInformation[]
-
-        /// The active signature. If omitted or the value lies outside the
-        /// range of `signatures` the value defaults to zero or is ignored if
-        /// `signatures.length === 0`. Whenever possible implementors should
-        /// make an active decision about the active signature and shouldn't
-        /// rely on a default value.
-        /// In future version of the protocol this property might become
-        /// mandatory to better express this.
-        ActiveSignature: int option
-
-        /// The active parameter of the active signature. If omitted or the value
-        /// lies outside the range of `signatures[activeSignature].parameters`
-        /// defaults to 0 if the active signature has parameters. If
-        /// the active signature has no parameters it is ignored.
-        /// In future version of the protocol this property might become
-        /// mandatory to better express the active parameter if the
-        /// active signature does have any.
-        ActiveParameter: int option
-    }
-
-    type SignatureHelpTriggerKind =
-    /// manually invoked via command
-    | Invoked = 1
-    /// trigger by a configured trigger character
-    | TriggerCharacter = 2
-    /// triggered by cursor movement or document content changing
-    | ContentChange = 3
-
-    type SignatureHelpContext =
-      {
-        /// action that caused signature help to be triggered
-        TriggerKind: SignatureHelpTriggerKind
-        /// character that caused signature help to be triggered. None when kind is not TriggerCharacter.
-        TriggerCharacter: char option
-        /// true if signature help was already showing when this was triggered
-        IsRetrigger: bool
-        /// the current active SignatureHelp
-        ActiveSignatureHelp: SignatureHelp option
-
+        return response |> LspResult.success
       }
 
-    type SignatureHelpParams =
-      {
-        /// the text document
-        TextDocument: TextDocumentIdentifier
-        /// the position inside the text document
-        Position: Position
-        /// Additional information about the context in which a signature help request was triggered.
-        Context: SignatureHelpContext option
+    let lspClient =
+      clientCreator (
+        sendServerNotification,
+        { new ClientRequestSender with
+            member __.Send x t = sendServerRequest x t }
+      )
+
+    let mutable shutdownReceived = false
+    let mutable quitReceived = false
+    use quitSemaphore = new SemaphoreSlim(0, 1)
+
+    let onShutdown () = shutdownReceived <- true
+
+    jsonRpc.AddLocalRpcMethod("shutdown", Action(onShutdown))
+
+    let onExit () =
+      quitReceived <- true
+      quitSemaphore.Release() |> ignore
+
+    jsonRpc.AddLocalRpcMethod("exit", Action(onExit))
+
+    for handling in setupRequestHandlings lspClient do
+      let rpcMethodName = handling.Key
+      let rpcDelegate = handling.Value
+
+      let rpcAttribute = JsonRpcMethodAttribute(rpcMethodName)
+      rpcAttribute.UseSingleObjectParameterDeserialization <- true
+
+      jsonRpc.AddLocalRpcMethod(rpcDelegate.GetMethodInfo(), rpcDelegate.Target, rpcAttribute)
+
+    jsonRpc.StartListening()
+
+    quitSemaphore.Wait()
+
+    match shutdownReceived, quitReceived with
+    | true, true -> LspCloseReason.RequestedByClient
+    | false, true -> LspCloseReason.ErrorExitWithoutShutdown
+    | _ -> LspCloseReason.ErrorStreamClosed
+
+  type ServerRequestHandling<'server when 'server :> Ionide.LanguageServerProtocol.LspServer> =
+    { Run: 'server -> Delegate }
+
+  let serverRequestHandling<'server, 'param, 'result when 'server :> Ionide.LanguageServerProtocol.LspServer>
+    (run: 'server -> 'param -> AsyncLspResult<'result>)
+    : ServerRequestHandling<'server> =
+    { Run = fun s -> requestHandling (run s) }
+
+  let defaultRequestHandlings () : Map<string, ServerRequestHandling<'server>> =
+    let requestHandling = serverRequestHandling
+
+    [ "initialize", requestHandling (fun s p -> s.Initialize(p))
+      "initialized", requestHandling (fun s p -> s.Initialized(p) |> notificationSuccess)
+      "textDocument/hover", requestHandling (fun s p -> s.TextDocumentHover(p))
+      "textDocument/didOpen", requestHandling (fun s p -> s.TextDocumentDidOpen(p) |> notificationSuccess)
+      "textDocument/didChange", requestHandling (fun s p -> s.TextDocumentDidChange(p) |> notificationSuccess)
+      "textDocument/completion", requestHandling (fun s p -> s.TextDocumentCompletion(p))
+      "completionItem/resolve", requestHandling (fun s p -> s.CompletionItemResolve(p))
+      "textDocument/rename", requestHandling (fun s p -> s.TextDocumentRename(p))
+      "textDocument/definition", requestHandling (fun s p -> s.TextDocumentDefinition(p))
+      "textDocument/typeDefinition", requestHandling (fun s p -> s.TextDocumentTypeDefinition(p))
+      "textDocument/implementation", requestHandling (fun s p -> s.TextDocumentImplementation(p))
+      "textDocument/codeAction", requestHandling (fun s p -> s.TextDocumentCodeAction(p))
+      "codeAction/resolve", requestHandling (fun s p -> s.CodeActionResolve(p))
+      "textDocument/codeLens", requestHandling (fun s p -> s.TextDocumentCodeLens(p))
+      "codeLens/resolve", requestHandling (fun s p -> s.CodeLensResolve(p))
+      "textDocument/references", requestHandling (fun s p -> s.TextDocumentReferences(p))
+      "textDocument/documentHighlight", requestHandling (fun s p -> s.TextDocumentDocumentHighlight(p))
+      "textDocument/documentLink", requestHandling (fun s p -> s.TextDocumentDocumentLink(p))
+      "textDocument/signatureHelp", requestHandling (fun s p -> s.TextDocumentSignatureHelp(p))
+      "documentLink/resolve", requestHandling (fun s p -> s.DocumentLinkResolve(p))
+      "textDocument/documentColor", requestHandling (fun s p -> s.TextDocumentDocumentColor(p))
+      "textDocument/colorPresentation", requestHandling (fun s p -> s.TextDocumentColorPresentation(p))
+      "textDocument/formatting", requestHandling (fun s p -> s.TextDocumentFormatting(p))
+      "textDocument/rangeFormatting", requestHandling (fun s p -> s.TextDocumentRangeFormatting(p))
+      "textDocument/onTypeFormatting", requestHandling (fun s p -> s.TextDocumentOnTypeFormatting(p))
+      "textDocument/willSave", requestHandling (fun s p -> s.TextDocumentWillSave(p) |> notificationSuccess)
+      "textDocument/willSaveWaitUntil", requestHandling (fun s p -> s.TextDocumentWillSaveWaitUntil(p))
+      "textDocument/didSave", requestHandling (fun s p -> s.TextDocumentDidSave(p) |> notificationSuccess)
+      "textDocument/didClose", requestHandling (fun s p -> s.TextDocumentDidClose(p) |> notificationSuccess)
+      "textDocument/documentSymbol", requestHandling (fun s p -> s.TextDocumentDocumentSymbol(p))
+      "textDocument/foldingRange", requestHandling (fun s p -> s.TextDocumentFoldingRange(p))
+      "textDocument/selectionRange", requestHandling (fun s p -> s.TextDocumentSelectionRange(p))
+      "textDocument/semanticTokens/full", requestHandling (fun s p -> s.TextDocumentSemanticTokensFull(p))
+      "textDocument/semanticTokens/full/delta", requestHandling (fun s p -> s.TextDocumentSemanticTokensFullDelta(p))
+      "textDocument/semanticTokens/range", requestHandling (fun s p -> s.TextDocumentSemanticTokensRange(p))
+      "workspace/didChangeWatchedFiles",
+      requestHandling (fun s p -> s.WorkspaceDidChangeWatchedFiles(p) |> notificationSuccess)
+      "workspace/didChangeWorkspaceFolders",
+      requestHandling (fun s p ->
+        s.WorkspaceDidChangeWorkspaceFolders(p)
+        |> notificationSuccess)
+      "workspace/didChangeConfiguration",
+      requestHandling (fun s p -> s.WorkspaceDidChangeConfiguration(p) |> notificationSuccess)
+      "workspace/willCreateFiles", requestHandling (fun s p -> s.WorkspaceWillCreateFiles(p))
+      "workspace/didCreateFiles", requestHandling (fun s p -> s.WorkspaceDidCreateFiles(p) |> notificationSuccess)
+      "workspace/willRenameFiles", requestHandling (fun s p -> s.WorkspaceWillRenameFiles(p))
+      "workspace/didRenameFiles", requestHandling (fun s p -> s.WorkspaceDidRenameFiles(p) |> notificationSuccess)
+      "workspace/willDeleteFiles", requestHandling (fun s p -> s.WorkspaceWillDeleteFiles(p))
+      "workspace/didDeleteFiles", requestHandling (fun s p -> s.WorkspaceDidDeleteFiles(p) |> notificationSuccess)
+      "workspace/symbol", requestHandling (fun s p -> s.WorkspaceSymbol(p))
+      "workspace/executeCommand ", requestHandling (fun s p -> s.WorkspaceExecuteCommand(p))
+      "shutdown", requestHandling (fun s () -> s.Shutdown() |> notificationSuccess)
+      "exit", requestHandling (fun s () -> s.Exit() |> notificationSuccess) ]
+    |> Map.ofList
+
+  let start<'client, 'server when 'client :> Ionide.LanguageServerProtocol.LspClient and 'server :> Ionide.LanguageServerProtocol.LspServer>
+    (requestHandlings: Map<string, ServerRequestHandling<'server>>)
+    (input: Stream)
+    (output: Stream)
+    (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client)
+    (serverCreator: 'client -> 'server)
+    =
+    let requestHandlingSetup client =
+      let server = serverCreator client
+
+      requestHandlings
+      |> Map.map (fun _ requestHandling -> requestHandling.Run server)
+
+    startWithSetup requestHandlingSetup input output clientCreator
+
+module Client =
+  open System
+  open System.Diagnostics
+  open System.IO
+  open Ionide.LanguageServerProtocol
+  open Ionide.LanguageServerProtocol.JsonRpc
+  open Ionide.LanguageServerProtocol.Logging
+  open LspJsonConverters
+  open Newtonsoft.Json
+  open Newtonsoft.Json.Serialization
+  open Newtonsoft.Json.Linq
+
+
+  let logger = LogProvider.getLoggerByName "LSP Client"
+
+  let internal jsonSettings =
+    let result = JsonSerializerSettings(NullValueHandling = NullValueHandling.Ignore)
+    result.Converters.Add(OptionConverter())
+    result.Converters.Add(ErasedUnionConverter())
+    result.ContractResolver <- CamelCasePropertyNamesContractResolver()
+    result
+
+  let internal jsonSerializer = JsonSerializer.Create(jsonSettings)
+
+  let internal deserialize (token: JToken) = token.ToObject<'t>(jsonSerializer)
+
+  let internal serialize (o: 't) = JToken.FromObject(o, jsonSerializer)
+
+  type NotificationHandler = { Run: JToken -> Async<JToken option> }
+
+  let notificationHandling<'p, 'r> (handler: 'p -> Async<'r option>) : NotificationHandler =
+    let run (token: JToken) =
+      async {
+        try
+          let p = token.ToObject<'p>(jsonSerializer)
+          let! res = handler p
+
+          return
+            res
+            |> Option.map (fun n -> JToken.FromObject(n, jsonSerializer))
+        with
+        | _ -> return None
       }
-      interface ITextDocumentPositionParams with
-        member this.TextDocument with get () = this.TextDocument
-        member this.Position with get () = this.Position
 
-    type FoldingRangeParams = {
-        /// the document to generate ranges for
-        TextDocument: TextDocumentIdentifier
-    }
+    { Run = run }
 
-    module FoldingRangeKind =
-        let Comment = "comment"
-        let Imports = "imports"
-        let Region = "region"
-
-    type FoldingRange = {
-        /// The zero-based line number from where the folded range starts.
-        StartLine: int
-
-        /// The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
-        StartCharacter: int option
-
-        /// The zero-based line number where the folded range ends.
-        EndLine: int
-
-        /// The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
-        EndCharacter: int option
-
-        /// Describes the kind of the folding range such as 'comment' or 'region'. The kind
-        /// is used to categorize folding ranges and used by commands like 'Fold all comments'. See
-        /// [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
-        Kind: string option
-    }
-
-    type SelectionRangeParams = {
-        /// The document to generate ranges for
-        TextDocument: TextDocumentIdentifier
-
-        /// The positions inside the text document.
-        Positions: Position[]
-    }
-
-    type SelectionRange = {
-        /// The range of this selection range.
-        Range: Range
-
-        /// The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
-        Parent: SelectionRange option
-    }
-
-    type SemanticTokensParams = {
-      TextDocument: TextDocumentIdentifier
-    }
-
-    type SemanticTokensDeltaParams = {
-      TextDocument: TextDocumentIdentifier
-      /// The result id of a previous response. The result Id can either point to
-      /// a full response or a delta response depending on what was received last.
-      PreviousResultId: string
-    }
-
-    type SemanticTokensRangeParams = {
-      TextDocument: TextDocumentIdentifier
-      Range: Range
-    }
-
-    type SemanticTokens = {
-      /// An optional result id. If provided and clients support delta updating
-      /// the client will include the result id in the next semantic token request.
-      /// A server can then instead of computing all semantic tokens again simply
-      /// send a delta.
-      ResultId: string option
-      Data: uint32[]
-    }
-
-    type SemanticTokensEdit = {
-      /// The start offset of the edit.
-      Start: uint32
-
-      /// The count of elements to remove.
-      DeleteCount: uint32
-
-      /// The elements to insert.
-      Data: uint32[] option
-    }
-
-    type SemanticTokensDelta = {
-      ResultId: string option
-
-      /// The semantic token edits to transform a previous result into a new result.
-      Edits: SemanticTokensEdit[]
-    }
-    
-    /// Represents information on a file/folder create.
-    ///@since 3.16.0 
-    type FileCreate = {
-        /// A file:// URI for the location of the file/folder being created.
-        Uri: string
-    }
-    
-    /// The parameters sent in notifications/requests for user-initiated creation of files.
-    /// @since 3.16.0
-    type CreateFilesParams = {
-        /// An array of all files/folders created in this operation.
-        Files: FileCreate[]
-    }
-    
-    /// Represents information on a file/folder rename.
-    /// @since 3.16.0
-    type FileRename = {
-        /// A file:// URI for the original location of the file/folder being renamed.
-        OldUri: string
-        /// A file:// URI for the new location of the file/folder being renamed.
-        NewUri: string
-    }
-    
-    /// The parameters sent in notifications/requests for user-initiated renames of files.
-    /// @since 3.16.0
-    type RenameFilesParams = {
-        /// An array of all files/folders renamed in this operation. When a folder is renamed,
-        /// only the folder will be included, and not its children.
-        Files: FileRename[]
-    }
-    
-    /// Represents information on a file/folder create.
-    ///@since 3.16.0 
-    type FileDelete = {
-        /// A file:// URI for the location of the file/folder being deleted.
-        Uri: string
-    }
-    
-    /// The parameters sent in notifications/requests for user-initiated deletes of files.
-    /// @since 3.16.0
-    type DeleteFilesParams = {
-        /// An array of all files/folders deleted in this operation.
-        Files: FileDelete[]
-    }
-
-open Types
-
-module LowLevel =
+  // TODO: replace this module with StreamJsonRpc like we did for the server
+  module LowLevel =
     open System
     open System.IO
     open System.Text
@@ -2362,936 +411,239 @@ module LowLevel =
     let headerEncoding = Encoding.ASCII
 
     let private readLine (stream: Stream) =
-        let buffer = Array.zeroCreate<byte> headerBufferSize
-        let readCount = stream.Read(buffer, 0, 2)
-        let mutable count = readCount
-        if count < 2 then
-            None
-        else
-            // TODO: Check that we don't over-fill headerBufferSize
-            while count < headerBufferSize && (buffer.[count-2] <> cr && buffer.[count-1] <> lf) do
-                 let additionalBytesRead  = stream.Read(buffer, count, 1)
-                 // TODO: exit when additionalBytesRead = 0, end of stream
-                 count <- count + additionalBytesRead
+      let buffer = Array.zeroCreate<byte> headerBufferSize
+      let readCount = stream.Read(buffer, 0, 2)
+      let mutable count = readCount
 
-            if count >= headerBufferSize then
-                None
-            else
-                Some (headerEncoding.GetString(buffer, 0, count - 2))
+      if count < 2 then
+        None
+      else
+        // TODO: Check that we don't over-fill headerBufferSize
+        while count < headerBufferSize
+              && (buffer.[count - 2] <> cr && buffer.[count - 1] <> lf) do
+          let additionalBytesRead = stream.Read(buffer, count, 1)
+          // TODO: exit when additionalBytesRead = 0, end of stream
+          count <- count + additionalBytesRead
+
+        if count >= headerBufferSize then
+          None
+        else
+          Some(headerEncoding.GetString(buffer, 0, count - 2))
 
     let rec private readHeaders (stream: Stream) =
-        let line = readLine stream
-        match line with
-        | Some "" -> []
-        | Some line ->
-            let separatorPos = line.IndexOf(": ")
-            if separatorPos = -1 then
-                raise (Exception(sprintf "Separator not found in header '%s'" line))
-            else
-                let name = line.Substring(0, separatorPos)
-                let value = line.Substring(separatorPos + 2)
-                let otherHeaders = readHeaders stream
-                (name,value) :: otherHeaders
-        | None ->
-            raise (EndOfStreamException())
+      let line = readLine stream
+
+      match line with
+      | Some "" -> []
+      | Some line ->
+        let separatorPos = line.IndexOf(": ")
+
+        if separatorPos = -1 then
+          raise (Exception(sprintf "Separator not found in header '%s'" line))
+        else
+          let name = line.Substring(0, separatorPos)
+          let value = line.Substring(separatorPos + 2)
+          let otherHeaders = readHeaders stream
+          (name, value) :: otherHeaders
+      | None -> raise (EndOfStreamException())
 
     let read (stream: Stream) =
-        let headers = readHeaders stream
+      let headers = readHeaders stream
 
-        let contentLength =
-            headers
-            |> List.tryFind(fun (name, _) -> name = "Content-Length")
-            |> Option.map snd
-            |> Option.bind (fun s -> match Int32.TryParse(s) with | true, x -> Some x | _ -> None)
+      let contentLength =
+        headers
+        |> List.tryFind (fun (name, _) -> name = "Content-Length")
+        |> Option.map snd
+        |> Option.bind (fun s ->
+          match Int32.TryParse(s) with
+          | true, x -> Some x
+          | _ -> None)
 
-        if contentLength = None then
-            failwithf "Content-Length header not found"
-        else
-            let result = Array.zeroCreate<byte> contentLength.Value
-            let mutable readCount = 0
-            while readCount < contentLength.Value do
-                let toRead = contentLength.Value - readCount
-                let readInCurrentBatch = stream.Read(result, readCount, toRead)
-                readCount <- readCount + readInCurrentBatch
-            let str = Encoding.UTF8.GetString(result, 0, readCount)
-            headers, str
+      if contentLength = None then
+        failwithf "Content-Length header not found"
+      else
+        let result = Array.zeroCreate<byte> contentLength.Value
+        let mutable readCount = 0
+
+        while readCount < contentLength.Value do
+          let toRead = contentLength.Value - readCount
+          let readInCurrentBatch = stream.Read(result, readCount, toRead)
+          readCount <- readCount + readInCurrentBatch
+
+        let str = Encoding.UTF8.GetString(result, 0, readCount)
+        headers, str
 
     let write (stream: Stream) (data: string) =
-        let bytes = Encoding.UTF8.GetBytes(data)
-        let header = sprintf "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\nContent-Length: %d\r\n\r\n" bytes.Length
-        let headerBytes = Encoding.ASCII.GetBytes header
-        use ms = new MemoryStream(headerBytes.Length + bytes.Length)
-        ms.Write(headerBytes, 0, headerBytes.Length)
-        ms.Write(bytes, 0, bytes.Length)
-        stream.Write(ms.ToArray(), 0, int ms.Position)
-
-module JsonRpc =
-    open Newtonsoft.Json
-    open Newtonsoft.Json.Linq
-
-    type MessageTypeTest = {
-        [<JsonProperty("jsonrpc")>] Version: string
-        Id: int option
-        Method: string option
-    }
-    [<RequireQualifiedAccess>]
-    type MessageType =
-      | Notification
-      | Request
-      | Response
-      | Error
-
-    let getMessageType messageTest =
-      match messageTest with
-      | { Version = "2.0"; Id = Some _; Method = Some _; } -> MessageType.Request
-      | { Version = "2.0"; Id = Some _; Method = None; } -> MessageType.Response
-      | { Version = "2.0"; Id = None; Method = Some _; } -> MessageType.Notification
-      | _ -> MessageType.Error
-
-    type Request = {
-        [<JsonProperty("jsonrpc")>] Version: string
-        Id: int
-        Method: string
-        Params: JToken option
-    }
-    with
-        static member Create(id: int, method': string, rpcParams: JToken option) =
-            { Version = "2.0"; Id = id; Method = method'; Params = rpcParams }
-
-    type Notification = {
-        [<JsonProperty("jsonrpc")>] Version: string
-        Method: string
-        Params: JToken option
-    }
-    with
-        static member Create(method': string, rpcParams: JToken option) =
-            { Version = "2.0"; Method = method'; Params = rpcParams }
-
-    module ErrorCodes =
-        let parseError = -32700
-        let invalidRequest = -32600
-        let methodNotFound = -32601
-        let invalidParams = -32602
-        let internalError = -32603
-        let serverErrorStart = -32000
-        let serverErrorEnd = -32099
-
-    type Error = {
-        Code: int
-        Message: string
-        Data: JToken option
-    }
-    with
-        static member Create(code: int, message: string) =
-            { Code = code; Message = message; Data = None }
-        static member ParseError = Error.Create(ErrorCodes.parseError, "Parse error")
-        static member InvalidRequest = Error.Create(ErrorCodes.invalidRequest, "Invalid Request")
-        static member MethodNotFound = Error.Create(ErrorCodes.methodNotFound, "Method not found")
-        static member InvalidParams = Error.Create(ErrorCodes.invalidParams, "Invalid params")
-        static member InternalError = Error.Create(ErrorCodes.internalError, "Internal error")
-        static member InternalErrorMessage message = Error.Create(ErrorCodes.internalError, message)
-
-    type Response = {
-        [<JsonProperty("jsonrpc")>] Version: string
-        Id: int option
-        Error: Error option
-        [<JsonProperty(NullValueHandling=NullValueHandling.Include)>]
-        Result: JToken option
-    }
-    with
-        /// Json.NET conditional property serialization, controlled by naming convention
-        member x.ShouldSerializeResult() = x.Error.IsNone
-        static member Success(id: int, result: JToken option) =
-            { Version = "2.0"; Id = Some id; Result = result; Error = None }
-        static member Failure(id: int, error: Error) =
-            { Version = "2.0"; Id = Some id; Result = None; Error = Some error }
-
-type LspResult<'t> = Result<'t, JsonRpc.Error>
-type AsyncLspResult<'t> = Async<LspResult<'t>>
-
-module LspResult =
-    let success x : LspResult<_> =
-        Result.Ok x
-
-    let invalidParams s : LspResult<_> =
-        Result.Error (JsonRpc.Error.Create(JsonRpc.ErrorCodes.invalidParams, s))
-
-    let internalError<'a> (s: string): LspResult<'a> =
-        Result.Error (JsonRpc.Error.Create(JsonRpc.ErrorCodes.internalError, s))
-
-    let notImplemented<'a> : LspResult<'a> =
-        Result.Error (JsonRpc.Error.MethodNotFound)
-
-module AsyncLspResult =
-    let success x : AsyncLspResult<_> =
-        async.Return (Result.Ok x)
-
-    let invalidParams s : AsyncLspResult<_> =
-        async.Return (Result.Error (JsonRpc.Error.Create(JsonRpc.ErrorCodes.invalidParams, s)))
-
-    let internalError s : AsyncLspResult<_> =
-        async.Return (Result.Error (JsonRpc.Error.Create(JsonRpc.ErrorCodes.internalError, s)))
-
-    let notImplemented<'a> : AsyncLspResult<'a> =
-        async.Return (Result.Error (JsonRpc.Error.MethodNotFound))
-
-/// Return the JSON-RPC "not implemented" error
-let private notImplemented<'t> = async.Return LspResult.notImplemented<'t>
-
-/// Do nothing and ignore the notification
-let private ignoreNotification = async.Return(())
-
-open Types
-open Newtonsoft.Json.Linq
-
-[<AbstractClass>]
-type LspClient() =
-    /// The show message notification is sent from a server to a client to ask the client to display
-    /// a particular message in the user interface.
-    abstract member WindowShowMessage: ShowMessageParams -> Async<unit>
-    default __.WindowShowMessage(_) = ignoreNotification
-
-    /// The show message request is sent from a server to a client to ask the client to display
-    /// a particular message in the user interface. In addition to the show message notification the
-    /// request allows to pass actions and to wait for an answer from the client.
-    abstract member WindowShowMessageRequest: ShowMessageRequestParams -> AsyncLspResult<MessageActionItem option>
-    default __.WindowShowMessageRequest(_) = notImplemented
-
-    /// The log message notification is sent from the server to the client to ask the client to log
-    ///a particular message.
-    abstract member WindowLogMessage: LogMessageParams -> Async<unit>
-    default __.WindowLogMessage(_) = ignoreNotification
-
-    /// The telemetry notification is sent from the server to the client to ask the client to log
-    /// a telemetry event.
-    abstract member TelemetryEvent: Newtonsoft.Json.Linq.JToken -> Async<unit>
-    default __.TelemetryEvent(_) = ignoreNotification
-
-    /// The `client/registerCapability` request is sent from the server to the client to register for a new
-    /// capability on the client side. Not all clients need to support dynamic capability registration.
-    /// A client opts in via the dynamicRegistration property on the specific client capabilities. A client
-    /// can even provide dynamic registration for capability A but not for capability B.
-    abstract member ClientRegisterCapability: RegistrationParams -> AsyncLspResult<unit>
-    default __.ClientRegisterCapability(_) = notImplemented
-
-    /// The `client/unregisterCapability` request is sent from the server to the client to unregister a previously
-    /// registered capability.
-    abstract member ClientUnregisterCapability: UnregistrationParams -> AsyncLspResult<unit>
-    default __.ClientUnregisterCapability(_) = notImplemented
-
-    /// Many tools support more than one root folder per workspace. Examples for this are VS Code’s multi-root
-    /// support, Atom’s project folder support or Sublime’s project support. If a client workspace consists of
-    /// multiple roots then a server typically needs to know about this. The protocol up to know assumes one root
-    /// folder which is announce to the server by the rootUri property of the InitializeParams.
-    /// If the client supports workspace folders and announces them via the corresponding workspaceFolders client
-    /// capability the InitializeParams contain an additional property workspaceFolders with the configured
-    /// workspace folders when the server starts.
-    ///
-    /// The workspace/workspaceFolders request is sent from the server to the client to fetch the current open
-    /// list of workspace folders. Returns null in the response if only a single file is open in the tool.
-    /// Returns an empty array if a workspace is open but no folders are configured.
-    abstract member WorkspaceWorkspaceFolders: unit -> AsyncLspResult<WorkspaceFolder[] option>
-    default __.WorkspaceWorkspaceFolders() = notImplemented
-
-    /// The workspace/configuration request is sent from the server to the client to fetch configuration
-    /// settings from the client.
-    ///
-    /// The request can fetch n configuration settings in one roundtrip. The order of the returned configuration
-    /// settings correspond to the order of the passed ConfigurationItems (e.g. the first item in the response
-    /// is the result for the first configuration item in the params).
-    abstract member WorkspaceConfiguration : ConfigurationParams -> AsyncLspResult<Newtonsoft.Json.Linq.JToken[]>
-    default __.WorkspaceConfiguration(_) = notImplemented
-
-    abstract member WorkspaceApplyEdit : ApplyWorkspaceEditParams -> AsyncLspResult<ApplyWorkspaceEditResponse>
-    default __.WorkspaceApplyEdit(_) = notImplemented
-
-    /// The workspace/semanticTokens/refresh request is sent from the server to the client.
-    /// Servers can use it to ask clients to refresh the editors for which this server provides semantic tokens.
-    /// As a result the client should ask the server to recompute the semantic tokens for these editors.
-    /// This is useful if a server detects a project wide configuration change which requires a re-calculation
-    /// of all semantic tokens. Note that the client still has the freedom to delay the re-calculation of
-    /// the semantic tokens if for example an editor is currently not visible.
-    abstract member WorkspaceSemanticTokensRefresh: unit -> Async<unit>
-    default __.WorkspaceSemanticTokensRefresh() = ignoreNotification
-
-    /// Diagnostics notification are sent from the server to the client to signal results of validation runs.
-    ///
-    /// Diagnostics are “owned” by the server so it is the server’s responsibility to clear them if necessary.
-    /// The following rule is used for VS Code servers that generate diagnostics:
-    ///
-    /// * if a language is single file only (for example HTML) then diagnostics are cleared by the server when
-    ///   the file is closed.
-    /// * if a language has a project system (for example C#) diagnostics are not cleared when a file closes.
-    ///   When a project is opened all diagnostics for all files are recomputed (or read from a cache).
-    ///
-    /// When a file changes it is the server’s responsibility to re-compute diagnostics and push them to the
-    /// client. If the computed set is empty it has to push the empty array to clear former diagnostics.
-    /// Newly pushed diagnostics always replace previously pushed diagnostics. There is no merging that happens
-    /// on the client side.
-    abstract member TextDocumentPublishDiagnostics: PublishDiagnosticsParams -> Async<unit>
-    default __.TextDocumentPublishDiagnostics(_) = ignoreNotification
-
-
-
-[<AbstractClass>]
-type LspServer() =
-    interface System.IDisposable with
-      member x.Dispose() = x.Dispose()
-
-    abstract member Dispose : unit -> unit
-
-    /// The initialize request is sent as the first request from the client to the server.
-    /// The initialize request may only be sent once.
-    abstract member Initialize: InitializeParams -> AsyncLspResult<InitializeResult>
-    default __.Initialize(_) = notImplemented
-
-    /// The initialized notification is sent from the client to the server after the client received the result
-    /// of the initialize request but before the client is sending any other request or notification to the server.
-    /// The server can use the initialized notification for example to dynamically register capabilities.
-    /// The initialized notification may only be sent once.
-    abstract member Initialized: InitializedParams -> Async<unit>
-    default __.Initialized(_) = ignoreNotification
-
-    /// The shutdown request is sent from the client to the server. It asks the server to shut down, but to not
-    /// exit (otherwise the response might not be delivered correctly to the client). There is a separate exit
-    /// notification that asks the server to exit.
-    abstract member Shutdown : unit -> Async<unit>
-    default __.Shutdown() = ignoreNotification
-
-    /// A notification to ask the server to exit its process.
-    abstract member Exit : unit -> Async<unit>
-    default __.Exit() = ignoreNotification
-
-    /// The hover request is sent from the client to the server to request hover information at a given text
-    /// document position.
-    abstract member TextDocumentHover: TextDocumentPositionParams -> AsyncLspResult<Hover option>
-    default __.TextDocumentHover(_) = notImplemented
-
-    /// The document open notification is sent from the client to the server to signal newly opened text
-    /// documents.
-    ///
-    /// The document’s truth is now managed by the client and the server must not try to read the document’s
-    /// truth using the document’s uri. Open in this sense means it is managed by the client. It doesn't
-    /// necessarily mean that its content is presented in an editor. An open notification must not be sent
-    /// more than once without a corresponding close notification send before. This means open and close
-    /// notification must be balanced and the max open count for a particular textDocument is one.
-    abstract member TextDocumentDidOpen: DidOpenTextDocumentParams -> Async<unit>
-    default __.TextDocumentDidOpen(_) = ignoreNotification
-
-    /// The document change notification is sent from the client to the server to signal changes to a text document.
-    abstract member TextDocumentDidChange: DidChangeTextDocumentParams -> Async<unit>
-    default __.TextDocumentDidChange(_) = ignoreNotification
-
-    /// The Completion request is sent from the client to the server to compute completion items at a given
-    /// cursor position. Completion items are presented in the IntelliSense user interface.
-    ///
-    /// If computing full completion items is expensive, servers can additionally provide a handler for the
-    /// completion item resolve request (‘completionItem/resolve’). This request is sent when a completion
-    /// item is selected in the user interface. A typical use case is for example: the ‘textDocument/completion’
-    /// request doesn’t fill in the documentation property for returned completion items since it is expensive
-    /// to compute. When the item is selected in the user interface then a ‘completionItem/resolve’ request is
-    /// sent with the selected completion item as a param. The returned completion item should have the
-      /// documentation property filled in. The request can delay the computation of the detail and documentation
-    /// properties. However, properties that are needed for the initial sorting and filtering, like sortText,
-    /// filterText, insertText, and textEdit must be provided in the textDocument/completion request and must
-    /// not be changed during resolve.
-    abstract member TextDocumentCompletion: CompletionParams -> AsyncLspResult<CompletionList option>
-    default __.TextDocumentCompletion(_) = notImplemented
-
-    /// The request is sent from the client to the server to resolve additional information for a given
-    /// completion item.
-    abstract member CompletionItemResolve: CompletionItem -> AsyncLspResult<CompletionItem>
-    default __.CompletionItemResolve(_) = notImplemented
-
-    /// The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
-    abstract member TextDocumentRename: RenameParams -> AsyncLspResult<WorkspaceEdit option>
-    default __.TextDocumentRename(_) = notImplemented
-
-    /// The goto definition request is sent from the client to the server to resolve the definition location of
-    /// a symbol at a given text document position.
-    abstract member TextDocumentDefinition: TextDocumentPositionParams -> AsyncLspResult<GotoResult option>
-    default __.TextDocumentDefinition(_) = notImplemented
-
-    /// The references request is sent from the client to the server to resolve project-wide references for
-    /// the symbol denoted by the given text document position.
-    abstract member TextDocumentReferences: ReferenceParams -> AsyncLspResult<Location[] option>
-    default __.TextDocumentReferences(_) = notImplemented
-
-    /// The document highlight request is sent from the client to the server to resolve a document highlights
-    /// for a given text document position. For programming languages this usually highlights all references
-    /// to the symbol scoped to this file.
-    ///
-    /// However we kept `textDocument/documentHighlight` and `textDocument/references` separate requests since
-    /// the first one is allowed to be more fuzzy. Symbol matches usually have a DocumentHighlightKind of Read
-    /// or Write whereas fuzzy or textual matches use Text as the kind.
-    abstract member TextDocumentDocumentHighlight: TextDocumentPositionParams -> AsyncLspResult<DocumentHighlight[] option>
-    default __.TextDocumentDocumentHighlight(_) = notImplemented
-
-    /// The document links request is sent from the client to the server to request the location of links
-    /// in a document.
-    abstract member TextDocumentDocumentLink: DocumentLinkParams -> AsyncLspResult<DocumentLink[] option>
-    default __.TextDocumentDocumentLink(_) = notImplemented
-
-    /// The goto type definition request is sent from the client to the server to resolve the type definition
-    /// location of a symbol at a given text document position.
-    abstract member TextDocumentTypeDefinition: TextDocumentPositionParams -> AsyncLspResult<GotoResult option>
-    default __.TextDocumentTypeDefinition(_) = notImplemented
-
-    /// The goto implementation request is sent from the client to the server to resolve the implementation
-    /// location of a symbol at a given text document position.
-    abstract member TextDocumentImplementation: TextDocumentPositionParams -> AsyncLspResult<GotoResult option>
-    default __.TextDocumentImplementation(_) = notImplemented
-
-    /// The code action request is sent from the client to the server to compute commands for a given text
-    /// document and range. These commands are typically code fixes to either fix problems or to
-    /// beautify/refactor code. The result of a textDocument/codeAction request is an array of Command literals
-    /// which are typically presented in the user interface. When the command is selected the server should be
-    /// contacted again (via the workspace/executeCommand) request to execute the command.
-    abstract member TextDocumentCodeAction: CodeActionParams -> AsyncLspResult<TextDocumentCodeActionResult option>
-    default __.TextDocumentCodeAction(_) = notImplemented
-
-    /// The code action request is sent from the client to the server to compute commands for a given text
-    /// document and range. These commands are typically code fixes to either fix problems or to
-    /// beautify/refactor code. The result of a textDocument/codeAction request is an array of Command literals
-    /// which are typically presented in the user interface. When the command is selected the server should be
-    /// contacted again (via the workspace/executeCommand) request to execute the command.
-    abstract member CodeActionResolve: CodeAction -> AsyncLspResult<CodeAction option>
-    default __.CodeActionResolve(_) = notImplemented
-
-    /// The code lens request is sent from the client to the server to compute code lenses for a given
-    /// text document.
-    abstract member TextDocumentCodeLens: CodeLensParams -> AsyncLspResult<CodeLens[] option>
-    default __.TextDocumentCodeLens(_) = notImplemented
-
-    /// The code lens resolve request is sent from the client to the server to resolve the command for
-    /// a given code lens item.
-    abstract member CodeLensResolve: CodeLens -> AsyncLspResult<CodeLens>
-    default __.CodeLensResolve(_) = notImplemented
-
-    /// The signature help request is sent from the client to the server to request signature information at
-    /// a given cursor position.
-    abstract member TextDocumentSignatureHelp: SignatureHelpParams -> AsyncLspResult<SignatureHelp option>
-    default __.TextDocumentSignatureHelp(_) = notImplemented
-
-    /// The document link resolve request is sent from the client to the server to resolve the target of
-    /// a given document link.
-    abstract member DocumentLinkResolve: DocumentLink -> AsyncLspResult<DocumentLink>
-    default __.DocumentLinkResolve(_) = notImplemented
-
-    /// The document color request is sent from the client to the server to list all color references
-    /// found in a given text document. Along with the range, a color value in RGB is returned.
-    abstract member TextDocumentDocumentColor: DocumentColorParams -> AsyncLspResult<ColorInformation[]>
-    default __.TextDocumentDocumentColor(_) = notImplemented
-
-    /// The color presentation request is sent from the client to the server to obtain a list of
-    /// presentations for a color value at a given location. Clients can use the result to
-    abstract member TextDocumentColorPresentation: ColorPresentationParams -> AsyncLspResult<ColorPresentation[]>
-    default __.TextDocumentColorPresentation(_) = notImplemented
-
-    /// The document formatting request is sent from the client to the server to format a whole document.
-    abstract member TextDocumentFormatting: DocumentFormattingParams -> AsyncLspResult<TextEdit[] option>
-    default __.TextDocumentFormatting(_) = notImplemented
-
-    /// The document range formatting request is sent from the client to the server to format a given
-    /// range in a document.
-    abstract member TextDocumentRangeFormatting: DocumentRangeFormattingParams -> AsyncLspResult<TextEdit[] option>
-    default __.TextDocumentRangeFormatting(_) = notImplemented
-
-    /// The document on type formatting request is sent from the client to the server to format parts
-    /// of the document during typing.
-    abstract member TextDocumentOnTypeFormatting: DocumentOnTypeFormattingParams -> AsyncLspResult<TextEdit[] option>
-    default __.TextDocumentOnTypeFormatting(_) = notImplemented
-
-    /// The document symbol request is sent from the client to the server to return a flat list of all symbols
-    /// found in a given text document. Neither the symbol’s location range nor the symbol’s container name
-    /// should be used to infer a hierarchy.
-    abstract member TextDocumentDocumentSymbol: DocumentSymbolParams -> AsyncLspResult<U2<SymbolInformation[], DocumentSymbol[]> option>
-    default __.TextDocumentDocumentSymbol(_) = notImplemented
-
-    /// The watched files notification is sent from the client to the server when the client detects changes
-    /// to files watched by the language client. It is recommended that servers register for these file
-    /// events using the registration mechanism. In former implementations clients pushed file events without
-    /// the server actively asking for it.
-    abstract member WorkspaceDidChangeWatchedFiles: DidChangeWatchedFilesParams -> Async<unit>
-    default __.WorkspaceDidChangeWatchedFiles(_) = ignoreNotification
-
-    /// The `workspace/didChangeWorkspaceFolders` notification is sent from the client to the server to inform
-    /// the server about workspace folder configuration changes. The notification is sent by default if both
-    /// *ServerCapabilities/workspace/workspaceFolders* and *ClientCapabilities/workapce/workspaceFolders* are
-    /// true; or if the server has registered to receive this notification it first.
-    abstract member WorkspaceDidChangeWorkspaceFolders: DidChangeWorkspaceFoldersParams -> Async<unit>
-    default __.WorkspaceDidChangeWorkspaceFolders(_) = ignoreNotification
-
-    /// A notification sent from the client to the server to signal the change of configuration settings.
-    abstract member WorkspaceDidChangeConfiguration: DidChangeConfigurationParams -> Async<unit>
-    default __.WorkspaceDidChangeConfiguration(_) = ignoreNotification
-    
-    /// The will create files request is sent from the client to the server before files are actually created
-    /// as long as the creation is triggered from within the client either by a user action or by applying a
-    /// workspace edit
-    abstract member WorkspaceWillCreateFiles: CreateFilesParams -> AsyncLspResult<WorkspaceEdit option>
-    default __.WorkspaceWillCreateFiles(_) = notImplemented
-    
-    /// The did create files notification is sent from the client to the server when files were created
-    /// from within the client.
-    abstract member WorkspaceDidCreateFiles: CreateFilesParams -> Async<unit>
-    default __.WorkspaceDidCreateFiles(_) = ignoreNotification
-    
-    /// The will rename files request is sent from the client to the server before files are actually renamed
-    /// as long as the rename is triggered from within the client either by a user action or by applying a
-    /// workspace edit. 
-    abstract member WorkspaceWillRenameFiles: RenameFilesParams -> AsyncLspResult<WorkspaceEdit option>
-    default __.WorkspaceWillRenameFiles(_) = notImplemented
-    
-    /// The did rename files notification is sent from the client to the server when files were renamed from
-    /// within the client.
-    abstract member WorkspaceDidRenameFiles: RenameFilesParams -> Async<unit>
-    default __.WorkspaceDidRenameFiles(_) = ignoreNotification
-    
-    /// The will delete files request is sent from the client to the server before files are actually deleted
-    /// as long as the deletion is triggered from within the client either by a user action or by applying a
-    /// workspace edit. 
-    abstract member WorkspaceWillDeleteFiles: DeleteFilesParams -> AsyncLspResult<WorkspaceEdit option>
-    default __.WorkspaceWillDeleteFiles(_) = notImplemented
-    
-    /// The did delete files notification is sent from the client to the server when files were deleted from
-    /// within the client.
-    abstract member WorkspaceDidDeleteFiles: DeleteFilesParams -> Async<unit>
-    default __.WorkspaceDidDeleteFiles(_) = ignoreNotification
-
-    /// The workspace symbol request is sent from the client to the server to list project-wide symbols matching
-    /// the query string.
-    abstract member WorkspaceSymbol: WorkspaceSymbolParams -> AsyncLspResult<SymbolInformation[] option>
-    default __.WorkspaceSymbol(_) = notImplemented
-
-    /// The `workspace/executeCommand` request is sent from the client to the server to trigger command execution
-    /// on the server. In most cases the server creates a `WorkspaceEdit` structure and applies the changes to the
-    /// workspace using the request `workspace/applyEdit` which is sent from the server to the client.
-    abstract member WorkspaceExecuteCommand : ExecuteCommandParams -> AsyncLspResult<Newtonsoft.Json.Linq.JToken>
-    default __.WorkspaceExecuteCommand(_) = notImplemented
-
-    /// The document will save notification is sent from the client to the server before the document is
-    /// actually saved.
-    abstract member TextDocumentWillSave: WillSaveTextDocumentParams -> Async<unit>
-    default __.TextDocumentWillSave(_) = ignoreNotification
-
-    /// The document will save request is sent from the client to the server before the document is actually saved.
-    /// The request can return an array of TextEdits which will be applied to the text document before it is saved.
-    /// Please note that clients might drop results if computing the text edits took too long or if a server
-    /// constantly fails on this request. This is done to keep the save fast and reliable.
-    abstract member TextDocumentWillSaveWaitUntil: WillSaveTextDocumentParams -> AsyncLspResult<TextEdit[] option>
-    default __.TextDocumentWillSaveWaitUntil(_) = notImplemented
-
-    /// The document save notification is sent from the client to the server when the document was saved
-    /// in the client.
-    abstract member TextDocumentDidSave: DidSaveTextDocumentParams -> Async<unit>
-    default __.TextDocumentDidSave(_) = ignoreNotification
-
-    /// The document close notification is sent from the client to the server when the document got closed in the
-    /// client. The document’s truth now exists where the document’s uri points to (e.g. if the document’s uri is
-    /// a file uri the truth now exists on disk). As with the open notification the close notification is about
-    /// managing the document’s content. Receiving a close notification doesn't mean that the document was open in
-    /// an editor before. A close notification requires a previous open notification to be sent.
-    abstract member TextDocumentDidClose: DidCloseTextDocumentParams -> Async<unit>
-    default __.TextDocumentDidClose(_) = ignoreNotification
-
-    /// The folding range request is sent from the client to the server to return all folding ranges found in a given text document.
-    abstract member TextDocumentFoldingRange: FoldingRangeParams -> AsyncLspResult<FoldingRange list option>
-    default __.TextDocumentFoldingRange(_) = notImplemented
-
-    /// The selection range request is sent from the client to the server to return suggested selection ranges at an array of given positions.
-    /// A selection range is a range around the cursor position which the user might be interested in selecting.
-    abstract member TextDocumentSelectionRange: SelectionRangeParams -> AsyncLspResult<SelectionRange list option>
-    default __.TextDocumentSelectionRange(_) = notImplemented
-
-    abstract member TextDocumentSemanticTokensFull: SemanticTokensParams -> AsyncLspResult<SemanticTokens option>
-    default __.TextDocumentSemanticTokensFull(_) = notImplemented
-
-    abstract member TextDocumentSemanticTokensFullDelta: SemanticTokensDeltaParams -> AsyncLspResult<U2<SemanticTokens, SemanticTokensDelta> option>
-    default __.TextDocumentSemanticTokensFullDelta(_) = notImplemented
-
-    abstract member TextDocumentSemanticTokensRange: SemanticTokensRangeParams -> AsyncLspResult<SemanticTokens option>
-    default __.TextDocumentSemanticTokensRange(_) = notImplemented
-
-module Server =
-    open System
-    open System.IO
-    open LanguageServerProtocol.Logging
-    open System.Threading
-    open System.Threading.Tasks
-    open System.Reflection
-    open StreamJsonRpc
-    open Newtonsoft.Json
-    open Newtonsoft.Json.Serialization
-
-    let logger = LogProvider.getLoggerByName "LSP Server"
-
-    let jsonRpcFormatter = new JsonMessageFormatter()
-    jsonRpcFormatter.JsonSerializer.NullValueHandling <- NullValueHandling.Ignore
-    jsonRpcFormatter.JsonSerializer.ConstructorHandling <- ConstructorHandling.AllowNonPublicDefaultConstructor
-    jsonRpcFormatter.JsonSerializer.MissingMemberHandling <- MissingMemberHandling.Ignore
-    jsonRpcFormatter.JsonSerializer.Converters.Add(SingleCaseUnionConverter())
-    jsonRpcFormatter.JsonSerializer.Converters.Add(U2BoolObjectConverter())
-    jsonRpcFormatter.JsonSerializer.Converters.Add(OptionConverter())
-    jsonRpcFormatter.JsonSerializer.Converters.Add(ErasedUnionConverter())
-    jsonRpcFormatter.JsonSerializer.ContractResolver <- CamelCasePropertyNamesContractResolver()
-
-    let deserialize<'t> (token: JToken) = token.ToObject<'t>(jsonRpcFormatter.JsonSerializer)
-    let serialize<'t> (o: 't) = JToken.FromObject(o, jsonRpcFormatter.JsonSerializer)
-
-    let requestHandling<'param, 'result> (run: 'param -> AsyncLspResult<'result>): Delegate =
-        let runAsTask param ct =
-            let asyncLspResult = run param
-
-            let asyncContinuation = async {
-                let! lspResult = asyncLspResult
-
-                return
-                    match lspResult with
-                    | Ok result -> result
-                    | Error error ->
-                        let rpcException = LocalRpcException(error.Message)
-                        rpcException.ErrorCode <- error.Code
-                        rpcException.ErrorData <- error.Data |> Option.defaultValue null
-                        raise rpcException
+      let bytes = Encoding.UTF8.GetBytes(data)
+
+      let header =
+        sprintf "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\nContent-Length: %d\r\n\r\n" bytes.Length
+
+      let headerBytes = Encoding.ASCII.GetBytes header
+      use ms = new MemoryStream(headerBytes.Length + bytes.Length)
+      ms.Write(headerBytes, 0, headerBytes.Length)
+      ms.Write(bytes, 0, bytes.Length)
+      stream.Write(ms.ToArray(), 0, int ms.Position)
+
+  type Client(exec: string, args: string, notificationHandlings: Map<string, NotificationHandler>) =
+
+    let mutable outuptStream: StreamReader option = None
+    let mutable inputStream: StreamWriter option = None
+
+    let sender =
+      MailboxProcessor<string>.Start
+        (fun inbox ->
+          let rec loop () =
+            async {
+              let! str = inbox.Receive()
+
+              inputStream
+              |> Option.iter (fun input ->
+                // fprintfn stderr "[CLIENT] Writing: %s" str
+                LowLevel.write input.BaseStream str
+                input.BaseStream.Flush())
+              // do! Async.Sleep 1000
+              return! loop ()
             }
 
-            Async.StartAsTask(asyncContinuation, cancellationToken=ct)
+          loop ())
 
-        Func<'param, CancellationToken, Task<'result>>(runAsTask) :> Delegate
+    let handleRequest (request: JsonRpc.Request) =
+      async {
+        let mutable methodCallResult = None
 
-    /// Notifications don't generate a response or error, but to unify things we consider them as always successful.
-    /// They will still not send any response because their ID is null.
-    let private notificationSuccess (response: Async<unit>) = async {
-        do! response
-        return Result.Ok ()
-    }
+        match notificationHandlings |> Map.tryFind request.Method with
+        | Some handling ->
+          try
+            match request.Params with
+            | None -> ()
+            | Some prms ->
+              let! result = handling.Run prms
+              methodCallResult <- result
+          with
+          | ex -> methodCallResult <- None
+        | None -> ()
 
-    type ClientNotificationSender = string -> obj -> AsyncLspResult<unit>
+        match methodCallResult with
+        | Some ok -> return Some(JsonRpc.Response.Success(request.Id, Some ok))
+        | None -> return None
+      }
 
-    type ClientRequestSender =
-        abstract member Send<'a> : string -> obj -> AsyncLspResult<'a>
+    let handleNotification (notification: JsonRpc.Notification) =
+      async {
+        match notificationHandlings |> Map.tryFind notification.Method with
+        | Some handling ->
+          try
+            match notification.Params with
+            | None -> return Result.Error(JsonRpc.Error.InvalidParams)
+            | Some prms ->
+              let! result = handling.Run prms
+              return Result.Ok()
+          with
+          | ex -> return Result.Error(JsonRpc.Error.Create(JsonRpc.ErrorCodes.internalError, ex.ToString()))
+        | None -> return Result.Error(JsonRpc.Error.MethodNotFound)
+      }
 
-    type private MessageHandlingResult =
-        | Normal
-        | WasExit
-        | WasShutdown
+    let messageHandler str =
+      let messageTypeTest = JsonConvert.DeserializeObject<JsonRpc.MessageTypeTest>(str, jsonSettings)
 
-    type LspCloseReason =
-        | RequestedByClient = 0
-        | ErrorExitWithoutShutdown = 1
-        | ErrorStreamClosed = 2
+      match getMessageType messageTypeTest with
+      | MessageType.Notification ->
+        let notification = JsonConvert.DeserializeObject<JsonRpc.Notification>(str, jsonSettings)
 
-    let startWithSetup<'client when 'client :> LspClient> (setupRequestHandlings : 'client -> Map<string,Delegate>) (input: Stream) (output: Stream) (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client) =
+        async {
+          let! result = handleNotification notification
 
-        use jsonRpcHandler = new HeaderDelimitedMessageHandler(output, input, jsonRpcFormatter)
-        use jsonRpc = new JsonRpc(jsonRpcHandler)
-
-        /// When the server wants to send a notification to the client
-        let sendServerNotification (rpcMethod: string) (notificationObj: obj): AsyncLspResult<unit> = async {
-            do! jsonRpc.NotifyWithParameterObjectAsync(rpcMethod, notificationObj)
-                |> Async.AwaitTask
-
-            return () |> LspResult.success
+          match result with
+          | Result.Ok _ -> ()
+          | Result.Error error ->
+            logger.error (
+              Log.setMessage "HandleServerMessage - Error {error} when handling notification {notification}"
+              >> Log.addContextDestructured "error" error
+              >> Log.addContextDestructured "notification" notification
+            )
+            //TODO: Handle error on receiving notification, send message to user?
+            ()
         }
+        |> Async.StartAsTask
+        |> ignore
+      | MessageType.Request ->
+        let request = JsonConvert.DeserializeObject<JsonRpc.Request>(str, jsonSettings)
 
-        /// When the server wants to send a request to the client
-        let sendServerRequest (rpcMethod: string) (requestObj: obj): AsyncLspResult<'response> = async {
-            let! response =
-                jsonRpc.InvokeWithParameterObjectAsync<'response>(rpcMethod, requestObj)
-                |> Async.AwaitTask
+        async {
+          let! result = handleRequest request
 
-            return response |> LspResult.success
+          match result with
+          | Some response ->
+            let responseString = JsonConvert.SerializeObject(response, jsonSettings)
+            sender.Post(responseString)
+          | None -> ()
         }
+        |> Async.StartAsTask
+        |> ignore
+      | MessageType.Response
+      | MessageType.Error ->
+        logger.error (
+          Log.setMessage "HandleServerMessage - Message had invalid jsonrpc version: {messageTypeTest}"
+          >> Log.addContextDestructured "messageTypeTest" messageTypeTest
+        )
 
-        let lspClient = clientCreator (sendServerNotification, { new ClientRequestSender with member __.Send x t  = sendServerRequest x t})
+        ()
 
-        let mutable shutdownReceived = false
-        let mutable quitReceived = false
-        use quitSemaphore = new SemaphoreSlim(0, 1)
+      let request = JsonConvert.DeserializeObject<JsonRpc.Request>(str, jsonSettings)
 
-        let onShutdown() =
-            shutdownReceived <- true
+      async {
+        let! result = handleRequest request
 
-        jsonRpc.AddLocalRpcMethod("shutdown", Action(onShutdown))
+        match result with
+        | Some response ->
+          let responseString = JsonConvert.SerializeObject(response, jsonSettings)
+          sender.Post(responseString)
+        | None -> ()
+      }
+      |> Async.StartAsTask
+      |> ignore
 
-        let onExit () =
-            quitReceived <- true
-            quitSemaphore.Release() |> ignore
+    member __.SendNotification (rpcMethod: string) (requestObj: obj) =
+      let serializedResponse = JToken.FromObject(requestObj, jsonSerializer)
+      let notification = JsonRpc.Notification.Create(rpcMethod, Some serializedResponse)
+      let notString = JsonConvert.SerializeObject(notification, jsonSettings)
+      sender.Post(notString)
 
-        jsonRpc.AddLocalRpcMethod("exit", Action(onExit))
+    member __.Start() =
+      async {
+        let si = ProcessStartInfo()
+        si.RedirectStandardOutput <- true
+        si.RedirectStandardInput <- true
+        si.RedirectStandardError <- true
+        si.UseShellExecute <- false
+        si.WorkingDirectory <- Environment.CurrentDirectory
+        si.FileName <- exec
+        si.Arguments <- args
 
-        for handling in setupRequestHandlings lspClient do
-            let rpcMethodName = handling.Key
-            let rpcDelegate = handling.Value
+        let proc =
+          try
+            Process.Start(si)
+          with
+          | ex ->
+            let newEx = System.Exception(sprintf "%s on %s" ex.Message exec, ex)
+            raise newEx
 
-            let rpcAttribute = JsonRpcMethodAttribute(rpcMethodName)
-            rpcAttribute.UseSingleObjectParameterDeserialization <- true
+        inputStream <- Some(proc.StandardInput)
+        outuptStream <- Some(proc.StandardOutput)
 
-            jsonRpc.AddLocalRpcMethod(rpcDelegate.GetMethodInfo(), rpcDelegate.Target, rpcAttribute)
+        let mutable quit = false
+        let outStream = proc.StandardOutput.BaseStream
 
-        jsonRpc.StartListening()
+        while not quit do
+          try
+            let _, notificationString = LowLevel.read outStream
+            // fprintfn stderr "[CLIENT] READING: %s" notificationString
+            messageHandler notificationString
+          with
+          | :? EndOfStreamException -> quit <- true
+          | ex -> ()
 
-        quitSemaphore.Wait()
-
-        match shutdownReceived, quitReceived with
-        | true, true -> LspCloseReason.RequestedByClient
-        | false, true -> LspCloseReason.ErrorExitWithoutShutdown
-        | _ -> LspCloseReason.ErrorStreamClosed
-
-    type ServerRequestHandling<'server when 'server :> LspServer> = {
-        Run: 'server -> Delegate
-    }
-
-    let serverRequestHandling<'server, 'param, 'result when 'server :> LspServer>
-            (run: 'server -> 'param -> AsyncLspResult<'result>): ServerRequestHandling<'server> =
-        { Run = fun s -> requestHandling (run s) }
-
-    let defaultRequestHandlings () : Map<string, ServerRequestHandling<'server>> =
-        let requestHandling = serverRequestHandling
-
-        [
-            "initialize", requestHandling (fun s p -> s.Initialize(p))
-            "initialized", requestHandling (fun s p -> s.Initialized(p) |> notificationSuccess)
-            "textDocument/hover", requestHandling (fun s p -> s.TextDocumentHover(p))
-            "textDocument/didOpen", requestHandling (fun s p -> s.TextDocumentDidOpen(p) |> notificationSuccess)
-            "textDocument/didChange", requestHandling (fun s p -> s.TextDocumentDidChange(p) |> notificationSuccess)
-            "textDocument/completion", requestHandling (fun s p -> s.TextDocumentCompletion(p))
-            "completionItem/resolve", requestHandling (fun s p -> s.CompletionItemResolve(p))
-            "textDocument/rename", requestHandling (fun s p -> s.TextDocumentRename(p))
-            "textDocument/definition", requestHandling (fun s p -> s.TextDocumentDefinition(p))
-            "textDocument/typeDefinition", requestHandling (fun s p -> s.TextDocumentTypeDefinition(p))
-            "textDocument/implementation", requestHandling (fun s p -> s.TextDocumentImplementation(p))
-            "textDocument/codeAction", requestHandling (fun s p -> s.TextDocumentCodeAction(p))
-            "codeAction/resolve", requestHandling (fun s p -> s.CodeActionResolve(p))
-            "textDocument/codeLens", requestHandling (fun s p -> s.TextDocumentCodeLens(p))
-            "codeLens/resolve", requestHandling (fun s p -> s.CodeLensResolve(p))
-            "textDocument/references", requestHandling (fun s p -> s.TextDocumentReferences(p))
-            "textDocument/documentHighlight", requestHandling (fun s p -> s.TextDocumentDocumentHighlight(p))
-            "textDocument/documentLink", requestHandling (fun s p -> s.TextDocumentDocumentLink(p))
-            "textDocument/signatureHelp", requestHandling (fun s p -> s.TextDocumentSignatureHelp(p))
-            "documentLink/resolve", requestHandling (fun s p -> s.DocumentLinkResolve(p))
-            "textDocument/documentColor", requestHandling (fun s p -> s.TextDocumentDocumentColor(p))
-            "textDocument/colorPresentation", requestHandling (fun s p -> s.TextDocumentColorPresentation(p))
-            "textDocument/formatting", requestHandling (fun s p -> s.TextDocumentFormatting(p))
-            "textDocument/rangeFormatting", requestHandling (fun s p -> s.TextDocumentRangeFormatting(p))
-            "textDocument/onTypeFormatting", requestHandling (fun s p -> s.TextDocumentOnTypeFormatting(p))
-            "textDocument/willSave", requestHandling (fun s p -> s.TextDocumentWillSave(p) |> notificationSuccess)
-            "textDocument/willSaveWaitUntil", requestHandling (fun s p -> s.TextDocumentWillSaveWaitUntil(p))
-            "textDocument/didSave", requestHandling (fun s p -> s.TextDocumentDidSave(p) |> notificationSuccess)
-            "textDocument/didClose", requestHandling (fun s p -> s.TextDocumentDidClose(p) |> notificationSuccess)
-            "textDocument/documentSymbol", requestHandling (fun s p -> s.TextDocumentDocumentSymbol(p))
-            "textDocument/foldingRange", requestHandling (fun s p -> s.TextDocumentFoldingRange(p))
-            "textDocument/selectionRange", requestHandling (fun s p -> s.TextDocumentSelectionRange(p))
-            "textDocument/semanticTokens/full", requestHandling(fun s p -> s.TextDocumentSemanticTokensFull(p))
-            "textDocument/semanticTokens/full/delta", requestHandling(fun s p -> s.TextDocumentSemanticTokensFullDelta(p))
-            "textDocument/semanticTokens/range", requestHandling(fun s p -> s.TextDocumentSemanticTokensRange(p))
-            "workspace/didChangeWatchedFiles", requestHandling (fun s p -> s.WorkspaceDidChangeWatchedFiles(p) |> notificationSuccess)
-            "workspace/didChangeWorkspaceFolders", requestHandling (fun s p -> s.WorkspaceDidChangeWorkspaceFolders (p) |> notificationSuccess)
-            "workspace/didChangeConfiguration", requestHandling (fun s p -> s.WorkspaceDidChangeConfiguration (p) |> notificationSuccess)
-            "workspace/willCreateFiles", requestHandling (fun s p -> s.WorkspaceWillCreateFiles(p))
-            "workspace/didCreateFiles", requestHandling (fun s p -> s.WorkspaceDidCreateFiles(p) |> notificationSuccess)
-            "workspace/willRenameFiles", requestHandling (fun s p -> s.WorkspaceWillRenameFiles(p))
-            "workspace/didRenameFiles", requestHandling (fun s p -> s.WorkspaceDidRenameFiles(p) |> notificationSuccess)
-            "workspace/willDeleteFiles", requestHandling (fun s p -> s.WorkspaceWillDeleteFiles(p))
-            "workspace/didDeleteFiles", requestHandling (fun s p -> s.WorkspaceDidDeleteFiles(p) |> notificationSuccess)
-            "workspace/symbol", requestHandling (fun s p -> s.WorkspaceSymbol (p))
-            "workspace/executeCommand ", requestHandling (fun s p -> s.WorkspaceExecuteCommand (p))
-            "shutdown", requestHandling (fun s () -> s.Shutdown() |> notificationSuccess)
-            "exit", requestHandling (fun s () -> s.Exit() |> notificationSuccess)
-        ]
-        |> Map.ofList
-
-    let start<'client, 'server when 'client :> LspClient and 'server :> LspServer> (requestHandlings : Map<string, ServerRequestHandling<'server>>) (input: Stream) (output: Stream) (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client) (serverCreator: 'client -> 'server) =
-        let requestHandlingSetup client =
-            let server = serverCreator client
-            requestHandlings
-            |> Map.map (fun _ requestHandling -> requestHandling.Run server)
-
-        startWithSetup requestHandlingSetup input output clientCreator
-
-module Client =
-    open System
-    open System.IO
-    open LanguageServerProtocol.Logging
-    open Newtonsoft.Json
-    open Newtonsoft.Json.Serialization
-
-    open JsonRpc
-
-    let logger = LogProvider.getLoggerByName "LSP Client"
-
-    let internal jsonSettings =
-            let result = JsonSerializerSettings(NullValueHandling = NullValueHandling.Ignore)
-            result.Converters.Add(OptionConverter())
-            result.Converters.Add(ErasedUnionConverter())
-            result.ContractResolver <- CamelCasePropertyNamesContractResolver()
-            result
-
-    let internal jsonSerializer = JsonSerializer.Create(jsonSettings)
-
-    let internal deserialize (token: JToken) = token.ToObject<'t>(jsonSerializer)
-
-    let internal serialize (o: 't) = JToken.FromObject(o, jsonSerializer)
-
-    type NotificationHandler = {
-        Run: JToken -> Async<JToken option>
-    }
-
-    let notificationHandling<'p, 'r> (handler: 'p -> Async<'r option>) : NotificationHandler =
-        let run (token: JToken) =
-            async {
-                try
-                    let p = token.ToObject<'p>(jsonSerializer)
-                    let! res = handler p
-                    return res |> Option.map (fun n -> JToken.FromObject(n, jsonSerializer))
-                with
-                | _ -> return None
-            }
-        {Run = run}
-
-    type Client(exec: string, args: string, notificationHandlings: Map<string, NotificationHandler>) =
-
-        let mutable outuptStream : StreamReader option = None
-        let mutable inputStream : StreamWriter option = None
-
-        let sender = MailboxProcessor<string>.Start(fun inbox ->
-            let rec loop () = async {
-                let! str = inbox.Receive()
-                inputStream |> Option.iter (fun input ->
-                    // fprintfn stderr "[CLIENT] Writing: %s" str
-                    LowLevel.write input.BaseStream str
-                    input.BaseStream.Flush()
-                    )
-                // do! Async.Sleep 1000
-                return! loop ()
-            }
-            loop ())
-
-        let handleRequest (request: JsonRpc.Request) =
-            async {
-                let mutable methodCallResult = None
-                match notificationHandlings |> Map.tryFind request.Method with
-                | Some handling ->
-                    try
-                        match request.Params with
-                        | None -> ()
-                        | Some prms ->
-                            let! result = handling.Run prms
-                            methodCallResult <- result
-                    with
-                    | ex ->
-                        methodCallResult <- None
-                | None -> ()
-
-                match methodCallResult with
-                | Some ok ->
-                    return Some (JsonRpc.Response.Success(request.Id, Some ok))
-                | None ->
-                    return None
-            }
-
-        let handleNotification (notification: JsonRpc.Notification) =
-            async {
-                match notificationHandlings |> Map.tryFind notification.Method with
-                | Some handling ->
-                    try
-                        match notification.Params with
-                        | None -> return Result.Error (Error.InvalidParams)
-                        | Some prms ->
-                            let! result = handling.Run prms
-                            return Result.Ok ()
-                    with
-                    | ex ->
-                        return Result.Error (Error.Create(ErrorCodes.internalError, ex.ToString()))
-                | None ->
-                  return Result.Error (Error.MethodNotFound)
-            }
-
-        let messageHanlder str =
-            let messageTypeTest = JsonConvert.DeserializeObject<JsonRpc.MessageTypeTest>(str, jsonSettings)
-            match getMessageType messageTypeTest with
-            | MessageType.Notification ->
-                let notification = JsonConvert.DeserializeObject<JsonRpc.Notification>(str, jsonSettings)
-                async {
-                  let! result = handleNotification notification
-                  match result with
-                  | Result.Ok _ -> ()
-                  | Result.Error error ->
-                    logger.error (Log.setMessage "HandleServerMessage - Error {error} when handling notification {notification}" >> Log.addContextDestructured "error" error >> Log.addContextDestructured "notification" notification)
-                    //TODO: Handle error on receiving notification, send message to user?
-                    ()
-                }
-                |> Async.StartAsTask
-                |> ignore
-            | MessageType.Request ->
-                let request = JsonConvert.DeserializeObject<JsonRpc.Request>(str, jsonSettings)
-                async {
-                  let! result = handleRequest request
-                  match result with
-                  | Some response ->
-                      let responseString = JsonConvert.SerializeObject(response, jsonSettings)
-                      sender.Post(responseString)
-                  | None -> ()
-                }
-                |> Async.StartAsTask
-                |> ignore
-            | MessageType.Response
-            | MessageType.Error ->
-                logger.error (Log.setMessage "HandleServerMessage - Message had invalid jsonrpc version: {messageTypeTest}" >> Log.addContextDestructured "messageTypeTest" messageTypeTest)
-                ()
-
-            let request = JsonConvert.DeserializeObject<JsonRpc.Request>(str, jsonSettings)
-            async {
-                let! result = handleRequest request
-                match result with
-                | Some response ->
-                    let responseString = JsonConvert.SerializeObject(response, jsonSettings)
-                    sender.Post(responseString)
-                | None -> ()
-            }
-            |> Async.StartAsTask
-            |> ignore
-
-        member __.SendNotification (rpcMethod: string) (requestObj: obj) =
-            let serializedResponse = JToken.FromObject(requestObj, jsonSerializer)
-            let notification = JsonRpc.Notification.Create(rpcMethod, Some serializedResponse)
-            let notString = JsonConvert.SerializeObject(notification, jsonSettings)
-            sender.Post(notString)
-
-        member __.Start() =
-            async {
-                let si = ProcessStartInfo()
-                si.RedirectStandardOutput <- true
-                si.RedirectStandardInput <- true
-                si.RedirectStandardError <- true
-                si.UseShellExecute <- false
-                si.WorkingDirectory <- Environment.CurrentDirectory
-                si.FileName <- exec
-                si.Arguments <- args
-                let proc =
-                    try
-                        Process.Start(si)
-                    with ex ->
-                        let newEx = System.Exception(sprintf "%s on %s" ex.Message exec, ex)
-                        raise newEx
-
-                inputStream <- Some (proc.StandardInput)
-                outuptStream <- Some (proc.StandardOutput)
-
-                let mutable quit = false
-                let outStream = proc.StandardOutput.BaseStream
-                while not quit do
-                    try
-                        let _, notificationString = LowLevel.read outStream
-                        // fprintfn stderr "[CLIENT] READING: %s" notificationString
-                        messageHanlder notificationString
-                    with
-                    | :? EndOfStreamException ->
-                        quit <- true
-                    | ex ->
-                        ()
-
-                return ()
-            } |> Async.Start
-
+        return ()
+      }
+      |> Async.Start

--- a/src/Server.fs
+++ b/src/Server.fs
@@ -1,0 +1,335 @@
+namespace Ionide.LanguageServerProtocol
+
+open Ionide.LanguageServerProtocol.Types
+
+module private ServerUtil =
+  /// Return the JSON-RPC "not implemented" error
+  let notImplemented<'t> = async.Return LspResult.notImplemented<'t>
+
+  /// Do nothing and ignore the notification
+  let ignoreNotification = async.Return(())
+
+open ServerUtil
+
+[<AbstractClass>]
+type LspServer() =
+  interface System.IDisposable with
+    member x.Dispose() = x.Dispose()
+
+  abstract member Dispose: unit -> unit
+
+  /// The initialize request is sent as the first request from the client to the server.
+  /// The initialize request may only be sent once.
+  abstract member Initialize: InitializeParams -> AsyncLspResult<InitializeResult>
+
+  default __.Initialize(_) = notImplemented
+
+  /// The initialized notification is sent from the client to the server after the client received the result
+  /// of the initialize request but before the client is sending any other request or notification to the server.
+  /// The server can use the initialized notification for example to dynamically register capabilities.
+  /// The initialized notification may only be sent once.
+  abstract member Initialized: InitializedParams -> Async<unit>
+
+  default __.Initialized(_) = ignoreNotification
+
+  /// The shutdown request is sent from the client to the server. It asks the server to shut down, but to not
+  /// exit (otherwise the response might not be delivered correctly to the client). There is a separate exit
+  /// notification that asks the server to exit.
+  abstract member Shutdown: unit -> Async<unit>
+
+  default __.Shutdown() = ignoreNotification
+
+  /// A notification to ask the server to exit its process.
+  abstract member Exit: unit -> Async<unit>
+  default __.Exit() = ignoreNotification
+
+  /// The hover request is sent from the client to the server to request hover information at a given text
+  /// document position.
+  abstract member TextDocumentHover: TextDocumentPositionParams -> AsyncLspResult<Hover option>
+
+  default __.TextDocumentHover(_) = notImplemented
+
+  /// The document open notification is sent from the client to the server to signal newly opened text
+  /// documents.
+  ///
+  /// The document’s truth is now managed by the client and the server must not try to read the document’s
+  /// truth using the document’s uri. Open in this sense means it is managed by the client. It doesn't
+  /// necessarily mean that its content is presented in an editor. An open notification must not be sent
+  /// more than once without a corresponding close notification send before. This means open and close
+  /// notification must be balanced and the max open count for a particular textDocument is one.
+  abstract member TextDocumentDidOpen: DidOpenTextDocumentParams -> Async<unit>
+
+  default __.TextDocumentDidOpen(_) = ignoreNotification
+
+  /// The document change notification is sent from the client to the server to signal changes to a text document.
+  abstract member TextDocumentDidChange: DidChangeTextDocumentParams -> Async<unit>
+  default __.TextDocumentDidChange(_) = ignoreNotification
+
+  /// The Completion request is sent from the client to the server to compute completion items at a given
+  /// cursor position. Completion items are presented in the IntelliSense user interface.
+  ///
+  /// If computing full completion items is expensive, servers can additionally provide a handler for the
+  /// completion item resolve request (‘completionItem/resolve’). This request is sent when a completion
+  /// item is selected in the user interface. A typical use case is for example: the ‘textDocument/completion’
+  /// request doesn’t fill in the documentation property for returned completion items since it is expensive
+  /// to compute. When the item is selected in the user interface then a ‘completionItem/resolve’ request is
+  /// sent with the selected completion item as a param. The returned completion item should have the
+  /// documentation property filled in. The request can delay the computation of the detail and documentation
+  /// properties. However, properties that are needed for the initial sorting and filtering, like sortText,
+  /// filterText, insertText, and textEdit must be provided in the textDocument/completion request and must
+  /// not be changed during resolve.
+  abstract member TextDocumentCompletion: CompletionParams -> AsyncLspResult<CompletionList option>
+
+  default __.TextDocumentCompletion(_) = notImplemented
+
+  /// The request is sent from the client to the server to resolve additional information for a given
+  /// completion item.
+  abstract member CompletionItemResolve: CompletionItem -> AsyncLspResult<CompletionItem>
+
+  default __.CompletionItemResolve(_) = notImplemented
+
+  /// The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
+  abstract member TextDocumentRename: RenameParams -> AsyncLspResult<WorkspaceEdit option>
+  default __.TextDocumentRename(_) = notImplemented
+
+  /// The goto definition request is sent from the client to the server to resolve the definition location of
+  /// a symbol at a given text document position.
+  abstract member TextDocumentDefinition: TextDocumentPositionParams -> AsyncLspResult<GotoResult option>
+
+  default __.TextDocumentDefinition(_) = notImplemented
+
+  /// The references request is sent from the client to the server to resolve project-wide references for
+  /// the symbol denoted by the given text document position.
+  abstract member TextDocumentReferences: ReferenceParams -> AsyncLspResult<Location [] option>
+
+  default __.TextDocumentReferences(_) = notImplemented
+
+  /// The document highlight request is sent from the client to the server to resolve a document highlights
+  /// for a given text document position. For programming languages this usually highlights all references
+  /// to the symbol scoped to this file.
+  ///
+  /// However we kept `textDocument/documentHighlight` and `textDocument/references` separate requests since
+  /// the first one is allowed to be more fuzzy. Symbol matches usually have a DocumentHighlightKind of Read
+  /// or Write whereas fuzzy or textual matches use Text as the kind.
+  abstract member TextDocumentDocumentHighlight:
+    TextDocumentPositionParams -> AsyncLspResult<DocumentHighlight [] option>
+
+  default __.TextDocumentDocumentHighlight(_) = notImplemented
+
+  /// The document links request is sent from the client to the server to request the location of links
+  /// in a document.
+  abstract member TextDocumentDocumentLink: DocumentLinkParams -> AsyncLspResult<DocumentLink [] option>
+
+  default __.TextDocumentDocumentLink(_) = notImplemented
+
+  /// The goto type definition request is sent from the client to the server to resolve the type definition
+  /// location of a symbol at a given text document position.
+  abstract member TextDocumentTypeDefinition: TextDocumentPositionParams -> AsyncLspResult<GotoResult option>
+
+  default __.TextDocumentTypeDefinition(_) = notImplemented
+
+  /// The goto implementation request is sent from the client to the server to resolve the implementation
+  /// location of a symbol at a given text document position.
+  abstract member TextDocumentImplementation: TextDocumentPositionParams -> AsyncLspResult<GotoResult option>
+
+  default __.TextDocumentImplementation(_) = notImplemented
+
+  /// The code action request is sent from the client to the server to compute commands for a given text
+  /// document and range. These commands are typically code fixes to either fix problems or to
+  /// beautify/refactor code. The result of a textDocument/codeAction request is an array of Command literals
+  /// which are typically presented in the user interface. When the command is selected the server should be
+  /// contacted again (via the workspace/executeCommand) request to execute the command.
+  abstract member TextDocumentCodeAction: CodeActionParams -> AsyncLspResult<TextDocumentCodeActionResult option>
+
+  default __.TextDocumentCodeAction(_) = notImplemented
+
+  /// The code action request is sent from the client to the server to compute commands for a given text
+  /// document and range. These commands are typically code fixes to either fix problems or to
+  /// beautify/refactor code. The result of a textDocument/codeAction request is an array of Command literals
+  /// which are typically presented in the user interface. When the command is selected the server should be
+  /// contacted again (via the workspace/executeCommand) request to execute the command.
+  abstract member CodeActionResolve: CodeAction -> AsyncLspResult<CodeAction option>
+
+  default __.CodeActionResolve(_) = notImplemented
+
+  /// The code lens request is sent from the client to the server to compute code lenses for a given
+  /// text document.
+  abstract member TextDocumentCodeLens: CodeLensParams -> AsyncLspResult<CodeLens [] option>
+
+  default __.TextDocumentCodeLens(_) = notImplemented
+
+  /// The code lens resolve request is sent from the client to the server to resolve the command for
+  /// a given code lens item.
+  abstract member CodeLensResolve: CodeLens -> AsyncLspResult<CodeLens>
+
+  default __.CodeLensResolve(_) = notImplemented
+
+  /// The signature help request is sent from the client to the server to request signature information at
+  /// a given cursor position.
+  abstract member TextDocumentSignatureHelp: SignatureHelpParams -> AsyncLspResult<SignatureHelp option>
+
+  default __.TextDocumentSignatureHelp(_) = notImplemented
+
+  /// The document link resolve request is sent from the client to the server to resolve the target of
+  /// a given document link.
+  abstract member DocumentLinkResolve: DocumentLink -> AsyncLspResult<DocumentLink>
+
+  default __.DocumentLinkResolve(_) = notImplemented
+
+  /// The document color request is sent from the client to the server to list all color references
+  /// found in a given text document. Along with the range, a color value in RGB is returned.
+  abstract member TextDocumentDocumentColor: DocumentColorParams -> AsyncLspResult<ColorInformation []>
+
+  default __.TextDocumentDocumentColor(_) = notImplemented
+
+  /// The color presentation request is sent from the client to the server to obtain a list of
+  /// presentations for a color value at a given location. Clients can use the result to
+  abstract member TextDocumentColorPresentation: ColorPresentationParams -> AsyncLspResult<ColorPresentation []>
+
+  default __.TextDocumentColorPresentation(_) = notImplemented
+
+  /// The document formatting request is sent from the client to the server to format a whole document.
+  abstract member TextDocumentFormatting: DocumentFormattingParams -> AsyncLspResult<TextEdit [] option>
+  default __.TextDocumentFormatting(_) = notImplemented
+
+  /// The document range formatting request is sent from the client to the server to format a given
+  /// range in a document.
+  abstract member TextDocumentRangeFormatting: DocumentRangeFormattingParams -> AsyncLspResult<TextEdit [] option>
+
+  default __.TextDocumentRangeFormatting(_) = notImplemented
+
+  /// The document on type formatting request is sent from the client to the server to format parts
+  /// of the document during typing.
+  abstract member TextDocumentOnTypeFormatting: DocumentOnTypeFormattingParams -> AsyncLspResult<TextEdit [] option>
+
+  default __.TextDocumentOnTypeFormatting(_) = notImplemented
+
+  /// The document symbol request is sent from the client to the server to return a flat list of all symbols
+  /// found in a given text document. Neither the symbol’s location range nor the symbol’s container name
+  /// should be used to infer a hierarchy.
+  abstract member TextDocumentDocumentSymbol:
+    DocumentSymbolParams -> AsyncLspResult<U2<SymbolInformation [], DocumentSymbol []> option>
+
+  default __.TextDocumentDocumentSymbol(_) = notImplemented
+
+  /// The watched files notification is sent from the client to the server when the client detects changes
+  /// to files watched by the language client. It is recommended that servers register for these file
+  /// events using the registration mechanism. In former implementations clients pushed file events without
+  /// the server actively asking for it.
+  abstract member WorkspaceDidChangeWatchedFiles: DidChangeWatchedFilesParams -> Async<unit>
+
+  default __.WorkspaceDidChangeWatchedFiles(_) = ignoreNotification
+
+  /// The `workspace/didChangeWorkspaceFolders` notification is sent from the client to the server to inform
+  /// the server about workspace folder configuration changes. The notification is sent by default if both
+  /// *ServerCapabilities/workspace/workspaceFolders* and *ClientCapabilities/workapce/workspaceFolders* are
+  /// true; or if the server has registered to receive this notification it first.
+  abstract member WorkspaceDidChangeWorkspaceFolders: DidChangeWorkspaceFoldersParams -> Async<unit>
+
+  default __.WorkspaceDidChangeWorkspaceFolders(_) = ignoreNotification
+
+  /// A notification sent from the client to the server to signal the change of configuration settings.
+  abstract member WorkspaceDidChangeConfiguration: DidChangeConfigurationParams -> Async<unit>
+  default __.WorkspaceDidChangeConfiguration(_) = ignoreNotification
+
+  /// The will create files request is sent from the client to the server before files are actually created
+  /// as long as the creation is triggered from within the client either by a user action or by applying a
+  /// workspace edit
+  abstract member WorkspaceWillCreateFiles: CreateFilesParams -> AsyncLspResult<WorkspaceEdit option>
+
+  default __.WorkspaceWillCreateFiles(_) = notImplemented
+
+  /// The did create files notification is sent from the client to the server when files were created
+  /// from within the client.
+  abstract member WorkspaceDidCreateFiles: CreateFilesParams -> Async<unit>
+
+  default __.WorkspaceDidCreateFiles(_) = ignoreNotification
+
+  /// The will rename files request is sent from the client to the server before files are actually renamed
+  /// as long as the rename is triggered from within the client either by a user action or by applying a
+  /// workspace edit.
+  abstract member WorkspaceWillRenameFiles: RenameFilesParams -> AsyncLspResult<WorkspaceEdit option>
+
+  default __.WorkspaceWillRenameFiles(_) = notImplemented
+
+  /// The did rename files notification is sent from the client to the server when files were renamed from
+  /// within the client.
+  abstract member WorkspaceDidRenameFiles: RenameFilesParams -> Async<unit>
+
+  default __.WorkspaceDidRenameFiles(_) = ignoreNotification
+
+  /// The will delete files request is sent from the client to the server before files are actually deleted
+  /// as long as the deletion is triggered from within the client either by a user action or by applying a
+  /// workspace edit.
+  abstract member WorkspaceWillDeleteFiles: DeleteFilesParams -> AsyncLspResult<WorkspaceEdit option>
+
+  default __.WorkspaceWillDeleteFiles(_) = notImplemented
+
+  /// The did delete files notification is sent from the client to the server when files were deleted from
+  /// within the client.
+  abstract member WorkspaceDidDeleteFiles: DeleteFilesParams -> Async<unit>
+
+  default __.WorkspaceDidDeleteFiles(_) = ignoreNotification
+
+  /// The workspace symbol request is sent from the client to the server to list project-wide symbols matching
+  /// the query string.
+  abstract member WorkspaceSymbol: WorkspaceSymbolParams -> AsyncLspResult<SymbolInformation [] option>
+
+  default __.WorkspaceSymbol(_) = notImplemented
+
+  /// The `workspace/executeCommand` request is sent from the client to the server to trigger command execution
+  /// on the server. In most cases the server creates a `WorkspaceEdit` structure and applies the changes to the
+  /// workspace using the request `workspace/applyEdit` which is sent from the server to the client.
+  abstract member WorkspaceExecuteCommand: ExecuteCommandParams -> AsyncLspResult<Newtonsoft.Json.Linq.JToken>
+
+  default __.WorkspaceExecuteCommand(_) = notImplemented
+
+  /// The document will save notification is sent from the client to the server before the document is
+  /// actually saved.
+  abstract member TextDocumentWillSave: WillSaveTextDocumentParams -> Async<unit>
+
+  default __.TextDocumentWillSave(_) = ignoreNotification
+
+  /// The document will save request is sent from the client to the server before the document is actually saved.
+  /// The request can return an array of TextEdits which will be applied to the text document before it is saved.
+  /// Please note that clients might drop results if computing the text edits took too long or if a server
+  /// constantly fails on this request. This is done to keep the save fast and reliable.
+  abstract member TextDocumentWillSaveWaitUntil: WillSaveTextDocumentParams -> AsyncLspResult<TextEdit [] option>
+
+  default __.TextDocumentWillSaveWaitUntil(_) = notImplemented
+
+  /// The document save notification is sent from the client to the server when the document was saved
+  /// in the client.
+  abstract member TextDocumentDidSave: DidSaveTextDocumentParams -> Async<unit>
+
+  default __.TextDocumentDidSave(_) = ignoreNotification
+
+  /// The document close notification is sent from the client to the server when the document got closed in the
+  /// client. The document’s truth now exists where the document’s uri points to (e.g. if the document’s uri is
+  /// a file uri the truth now exists on disk). As with the open notification the close notification is about
+  /// managing the document’s content. Receiving a close notification doesn't mean that the document was open in
+  /// an editor before. A close notification requires a previous open notification to be sent.
+  abstract member TextDocumentDidClose: DidCloseTextDocumentParams -> Async<unit>
+
+  default __.TextDocumentDidClose(_) = ignoreNotification
+
+  /// The folding range request is sent from the client to the server to return all folding ranges found in a given text document.
+  abstract member TextDocumentFoldingRange: FoldingRangeParams -> AsyncLspResult<FoldingRange list option>
+  default __.TextDocumentFoldingRange(_) = notImplemented
+
+  /// The selection range request is sent from the client to the server to return suggested selection ranges at an array of given positions.
+  /// A selection range is a range around the cursor position which the user might be interested in selecting.
+  abstract member TextDocumentSelectionRange: SelectionRangeParams -> AsyncLspResult<SelectionRange list option>
+
+  default __.TextDocumentSelectionRange(_) = notImplemented
+
+  abstract member TextDocumentSemanticTokensFull: SemanticTokensParams -> AsyncLspResult<SemanticTokens option>
+  default __.TextDocumentSemanticTokensFull(_) = notImplemented
+
+  abstract member TextDocumentSemanticTokensFullDelta:
+    SemanticTokensDeltaParams -> AsyncLspResult<U2<SemanticTokens, SemanticTokensDelta> option>
+
+  default __.TextDocumentSemanticTokensFullDelta(_) = notImplemented
+
+  abstract member TextDocumentSemanticTokensRange: SemanticTokensRangeParams -> AsyncLspResult<SemanticTokens option>
+  default __.TextDocumentSemanticTokensRange(_) = notImplemented

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -1,0 +1,2053 @@
+module Ionide.LanguageServerProtocol.Types
+
+open System.Diagnostics
+open Newtonsoft.Json
+open Newtonsoft.Json.Linq
+open System
+
+type ErasedUnionAttribute() =
+  inherit Attribute()
+
+[<ErasedUnion>]
+type U2<'a, 'b> =
+  | First of 'a
+  | Second of 'b
+
+type LspResult<'t> = Result<'t, JsonRpc.Error>
+type AsyncLspResult<'t> = Async<LspResult<'t>>
+
+module LspResult =
+  open Ionide.LanguageServerProtocol
+
+  let success x : LspResult<_> = Result.Ok x
+
+  let invalidParams s : LspResult<_> = Result.Error(JsonRpc.Error.Create(JsonRpc.ErrorCodes.invalidParams, s))
+
+  let internalError<'a> (s: string) : LspResult<'a> =
+    Result.Error(JsonRpc.Error.Create(JsonRpc.ErrorCodes.internalError, s))
+
+  let notImplemented<'a> : LspResult<'a> = Result.Error(JsonRpc.Error.MethodNotFound)
+
+module AsyncLspResult =
+  open Ionide.LanguageServerProtocol
+
+  let success x : AsyncLspResult<_> = async.Return(Result.Ok x)
+
+  let invalidParams s : AsyncLspResult<_> =
+    async.Return(Result.Error(JsonRpc.Error.Create(JsonRpc.ErrorCodes.invalidParams, s)))
+
+  let internalError s : AsyncLspResult<_> =
+    async.Return(Result.Error(JsonRpc.Error.Create(JsonRpc.ErrorCodes.internalError, s)))
+
+  let notImplemented<'a> : AsyncLspResult<'a> = async.Return(Result.Error(JsonRpc.Error.MethodNotFound))
+
+type TextDocumentSyncKind =
+  | None = 0
+  | Full = 1
+  | Incremental = 2
+
+type DocumentFilter =
+  { /// A language id, like `typescript`.
+    Language: string option
+
+    /// A Uri scheme, like `file` or `untitled`.
+    Scheme: string option
+
+    /// A glob pattern, like `*.{ts,js}`.
+    Pattern: string option }
+
+type DocumentSelector = DocumentFilter []
+
+/// Position in a text document expressed as zero-based line and zero-based character offset.
+/// A position is between two characters like an ‘insert’ cursor in a editor.
+[<DebuggerDisplay("{DebuggerDisplay}")>]
+type Position =
+  { /// Line position in a document (zero-based).
+    Line: int
+
+    /// Character offset on a line in a document (zero-based). Assuming that the line is
+    /// represented as a string, the `character` value represents the gap between the
+    /// `character` and `character + 1`.
+    ///
+    /// If the character value is greater than the line length it defaults back to the
+    /// line length.
+    Character: int }
+  [<DebuggerBrowsable(DebuggerBrowsableState.Never); JsonIgnore>]
+  member x.DebuggerDisplay = $"({x.Line},{x.Character})"
+
+/// A range in a text document expressed as (zero-based) start and end positions.
+/// A range is comparable to a selection in an editor. Therefore the end position is exclusive.
+///
+/// If you want to specify a range that contains a line including the line ending character(s)
+/// then use an end position denoting the start of the next line. For example:
+///
+/// ```fsharp
+/// {
+///     Start = { Line = 5; character = 23 }
+///     End = { Line = 6; character = 0 }
+/// }
+/// ```
+[<DebuggerDisplay("{DebuggerDisplay}")>]
+type Range =
+  { /// The range's start position.
+    Start: Position
+
+    /// The range's end position.
+    End: Position }
+  [<DebuggerBrowsable(DebuggerBrowsableState.Never); JsonIgnore>]
+  member x.DebuggerDisplay = $"{x.Start.DebuggerDisplay}-{x.End.DebuggerDisplay}"
+
+type DocumentUri = string
+
+/// Represents a location inside a resource, such as a line inside a text file.
+type Location = { Uri: DocumentUri; Range: Range }
+
+type ITextDocumentIdentifier =
+  /// Warning: normalize this member by UrlDecoding it before use
+  abstract member Uri: DocumentUri
+
+type TextDocumentIdentifier =
+  { /// The text document's URI.
+    Uri: DocumentUri }
+  interface ITextDocumentIdentifier with
+    member this.Uri = this.Uri
+
+type VersionedTextDocumentIdentifier =
+  { /// The text document's URI.
+    Uri: DocumentUri
+
+    /// The version number of this document. If a versioned text document identifier
+    /// is sent from the server to the client and the file is not open in the editor
+    /// (the server has not received an open notification before) the server can send
+    /// `null` to indicate that the version is known and the content on disk is the
+    /// truth (as speced with document content ownership)
+    /// Explicitly include the null value here.
+    [<JsonProperty(NullValueHandling = NullValueHandling.Include)>]
+    Version: int option }
+  interface ITextDocumentIdentifier with
+    member this.Uri = this.Uri
+
+type SymbolKind =
+  | File = 1
+  | Module = 2
+  | Namespace = 3
+  | Package = 4
+  | Class = 5
+  | Method = 6
+  | Property = 7
+  | Field = 8
+  | Constructor = 9
+  | Enum = 10
+  | Interface = 11
+  | Function = 12
+  | Variable = 13
+  | Constant = 14
+  | String = 15
+  | Number = 16
+  | Boolean = 17
+  | Array = 18
+  | Object = 19
+  | Key = 20
+  | Null = 21
+  | EnumMember = 22
+  | Struct = 23
+  | Event = 24
+  | Operator = 25
+  | TypeParameter = 26
+
+/// Represents information about programming constructs like variables, classes,
+/// interfaces etc.
+type SymbolInformation =
+  { /// The name of this symbol.
+    Name: string
+
+    /// The kind of this symbol.
+    Kind: SymbolKind
+
+    /// The location of this symbol. The location's range is used by a tool
+    /// to reveal the location in the editor. If the symbol is selected in the
+    /// tool the range's start information is used to position the cursor. So
+    /// the range usually spans more then the actual symbol's name and does
+    /// normally include things like visibility modifiers.
+    ///
+    /// The range doesn't have to denote a node range in the sense of a abstract
+    /// syntax tree. It can therefore not be used to re-construct a hierarchy of
+    /// the symbols.
+    Location: Location
+
+    /// The name of the symbol containing this symbol. This information is for
+    /// user interface purposes (e.g. to render a qualifier in the user interface
+    /// if necessary). It can't be used to re-infer a hierarchy for the document
+    /// symbols.
+    ContainerName: string option }
+
+/// Represents programming constructs like variables, classes, interfaces etc.
+/// that appear in a document. Document symbols can be hierarchical and they
+/// have two ranges: one that encloses its definition and one that points to its
+/// most interesting range, e.g. the range of an identifier.
+type DocumentSymbol =
+  { /// The name of this symbol. Will be displayed in the user interface and
+    /// therefore must not be an empty string or a string only consisting of
+    /// white spaces.
+    Name: string
+    /// More detail for this symbol, e.g the signature of a function.
+    Detail: string option
+    /// The kind of this symbol.
+    Kind: SymbolKind
+    /// The range enclosing this symbol not including leading/trailing whitespace
+    /// but everything else like comments. This information is typically used to
+    /// determine if the clients cursor is inside the symbol to reveal in the
+    /// symbol in the UI.
+    Range: Range
+    /// The range that should be selected and revealed when this symbol is being
+    /// picked, e.g. the name of a function. Must be contained by the `range`.
+    SelectionRange: Range
+    /// Children of this symbol, e.g. properties of a class.
+    Children: DocumentSymbol [] option }
+
+/// A textual edit applicable to a text document.
+type TextEdit =
+  { /// The range of the text document to be manipulated. To insert
+    /// text into a document create a range where start === end.
+    Range: Range
+
+    /// The string to be inserted. For delete operations use an
+    /// empty string.
+    NewText: string }
+
+/// Describes textual changes on a single text document. The text document is referred to as a
+/// `VersionedTextDocumentIdentifier` to allow clients to check the text document version before an edit is
+/// applied. A `TextDocumentEdit` describes all changes on a version Si and after they are applied move the
+/// document to version Si+1. So the creator of a `TextDocumentEdit `doesn't need to sort the array or do any
+/// kind of ordering. However the edits must be non overlapping.
+type TextDocumentEdit =
+  { /// The text document to change.
+    TextDocument: VersionedTextDocumentIdentifier
+
+    /// The edits to be applied.
+    Edits: TextEdit [] }
+
+type TraceSetting =
+  | Off = 0
+  | Messages = 1
+  | Verbose = 2
+
+/// Capabilities for methods that support dynamic registration.
+type DynamicCapabilities =
+  { /// Method supports dynamic registration.
+    DynamicRegistration: bool option }
+
+type ResourceOperationKind =
+  | Create
+  | Rename
+  | Delete
+
+type FailureHandlingKind =
+  | Abort
+  | Transactional
+  | Undo
+  | TextOnlyTransactional
+
+type ChangeAnnotationSupport = { GroupsOnLabel: bool option }
+
+/// Capabilities specific to `WorkspaceEdit`s
+type WorkspaceEditCapabilities =
+  { /// The client supports versioned document changes in `WorkspaceEdit`s
+    DocumentChanges: bool option
+    /// The resource operations the client supports. Clients should at least
+    /// support 'create', 'rename' and 'delete' files and folders.
+    ResourceOperations: ResourceOperationKind [] option
+    /// The failure handling strategy of a client if applying the workspace edit fails.
+    FailureHandling: FailureHandlingKind option
+    /// Whether the client normalizes line endings to the client specific setting.
+    /// If set to `true` the client will normalize line ending characters
+    /// in a workspace edit to the client specific new line character(s).
+    NormalizesLineEndings: bool option
+    /// Whether the client in general supports change annotations on text edits, create file, rename file and delete file changes.
+    ChangeAnnotationSupport: ChangeAnnotationSupport option }
+
+/// Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
+type SymbolKindCapabilities =
+  { /// The symbol kind values the client supports. When this
+    /// property exists the client also guarantees that it will
+    /// handle values outside its set gracefully and falls back
+    /// to a default value when unknown.
+    ///
+    /// If this property is not present the client only supports
+    /// the symbol kinds from `File` to `Array` as defined in
+    /// the initial version of the protocol.
+    ValueSet: SymbolKind [] option }
+  static member DefaultValueSet =
+    [| SymbolKind.File
+       SymbolKind.Module
+       SymbolKind.Namespace
+       SymbolKind.Package
+       SymbolKind.Class
+       SymbolKind.Method
+       SymbolKind.Property
+       SymbolKind.Field
+       SymbolKind.Constructor
+       SymbolKind.Enum
+       SymbolKind.Interface
+       SymbolKind.Function
+       SymbolKind.Variable
+       SymbolKind.Constant
+       SymbolKind.String
+       SymbolKind.Number
+       SymbolKind.Boolean
+       SymbolKind.Array |]
+
+/// Capabilities specific to the `workspace/symbol` request.
+type SymbolCapabilities =
+  { /// Symbol request supports dynamic registration.
+    DynamicRegistration: bool option
+
+    /// Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
+    SymbolKind: SymbolKindCapabilities option }
+
+type SemanticTokensWorkspaceClientCapabilities =
+  { /// Whether the client implementation supports a refresh request sent from
+    /// the server to the client.
+    ///
+    /// Note that this event is global and will force the client to refresh all
+    /// semantic tokens currently shown. It should be used with absolute care
+    /// and is useful for situation where a server for example detect a project
+    /// wide change that requires such a calculation.
+    RefreshSupport: bool option }
+
+/// Workspace specific client capabilities.
+type WorkspaceClientCapabilities =
+  { /// The client supports applying batch edits to the workspace by supporting
+    /// the request 'workspace/applyEdit'
+    ApplyEdit: bool option
+
+    /// Capabilities specific to `WorkspaceEdit`s
+    WorkspaceEdit: WorkspaceEditCapabilities option
+
+    /// Capabilities specific to the `workspace/didChangeConfiguration` notification.
+    DidChangeConfiguration: DynamicCapabilities option
+
+    /// Capabilities specific to the `workspace/didChangeWatchedFiles` notification.
+    DidChangeWatchedFiles: DynamicCapabilities option
+
+    /// Capabilities specific to the `workspace/symbol` request.
+    Symbol: SymbolCapabilities option
+
+    SemanticTokens: SemanticTokensWorkspaceClientCapabilities option }
+
+type SynchronizationCapabilities =
+  { /// Whether text document synchronization supports dynamic registration.
+    DynamicRegistration: bool option
+
+    /// The client supports sending will save notifications.
+    WillSave: bool option
+
+    /// The client supports sending a will save request and
+    /// waits for a response providing text edits which will
+    /// be applied to the document before it is saved.
+    WillSaveWaitUntil: bool option
+
+    /// The client supports did save notifications.
+    DidSave: bool option }
+
+module MarkupKind =
+  let PlainText = "plaintext"
+  let Markdown = "markdown"
+
+type HoverCapabilities =
+  { /// Whether hover synchronization supports dynamic registration.
+    DynamicRegistration: bool option
+
+    /// Client supports the follow content formats for the content
+    /// property. The order describes the preferred format of the client.
+    /// See `MarkupKind` for common values
+    ContentFormat: string [] option }
+
+type CompletionItemCapabilities =
+  { /// Client supports snippets as insert text.
+    ///
+    /// A snippet can define tab stops and placeholders with `$1`, `$2`
+    /// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+    /// the end of the snippet. Placeholders with equal identifiers are linked,
+    /// that is typing in one will update others too.
+    SnippetSupport: bool option
+
+    /// Client supports commit characters on a completion item.
+    CommitCharactersSupport: bool option
+
+    /// Client supports the follow content formats for the documentation
+    /// property. The order describes the preferred format of the client.
+    /// See `MarkupKind` for common values
+    DocumentationFormat: string [] option }
+
+type CompletionItemKind =
+  | Text = 1
+  | Method = 2
+  | Function = 3
+  | Constructor = 4
+  | Field = 5
+  | Variable = 6
+  | Class = 7
+  | Interface = 8
+  | Module = 9
+  | Property = 10
+  | Unit = 11
+  | Value = 12
+  | Enum = 13
+  | Keyword = 14
+  | Snippet = 15
+  | Color = 16
+  | File = 17
+  | Reference = 18
+  | Folder = 19
+  | EnumMember = 20
+  | Constant = 21
+  | Struct = 22
+  | Event = 23
+  | Operator = 24
+  | TypeParameter = 25
+
+type CompletionItemKindCapabilities =
+  { /// The completion item kind values the client supports. When this
+    /// property exists the client also guarantees that it will
+    /// handle values outside its set gracefully and falls back
+    /// to a default value when unknown.
+    ///
+    /// If this property is not present the client only supports
+    /// the completion items kinds from `Text` to `Reference` as defined in
+    /// the initial version of the protocol.
+    ValueSet: CompletionItemKind [] option }
+  static member DefaultValueSet =
+    [| CompletionItemKind.Text
+       CompletionItemKind.Method
+       CompletionItemKind.Function
+       CompletionItemKind.Constructor
+       CompletionItemKind.Field
+       CompletionItemKind.Variable
+       CompletionItemKind.Class
+       CompletionItemKind.Interface
+       CompletionItemKind.Module
+       CompletionItemKind.Property
+       CompletionItemKind.Unit
+       CompletionItemKind.Value
+       CompletionItemKind.Enum
+       CompletionItemKind.Keyword
+       CompletionItemKind.Snippet
+       CompletionItemKind.Color
+       CompletionItemKind.File
+       CompletionItemKind.Reference |]
+
+/// Capabilities specific to the `textDocument/completion`
+type CompletionCapabilities =
+  { /// Whether completion supports dynamic registration.
+    DynamicRegistration: bool option
+
+    /// The client supports the following `CompletionItem` specific
+    /// capabilities.
+    CompletionItem: CompletionItemCapabilities option
+
+    CompletionItemKind: CompletionItemKindCapabilities option
+
+    /// The client supports to send additional context information for a
+    /// `textDocument/completion` request.
+    ContextSupport: bool option }
+
+type SignatureInformationCapabilities =
+  { /// Client supports the follow content formats for the documentation
+    /// property. The order describes the preferred format of the client.
+    /// See `MarkupKind` for common values
+    DocumentationFormat: string [] option }
+
+type SignatureHelpCapabilities =
+  { /// Whether signature help supports dynamic registration.
+    DynamicRegistration: bool option
+
+    /// The client supports the following `SignatureInformation`
+    /// specific properties.
+    SignatureInformation: SignatureInformationCapabilities option }
+
+/// capabilities specific to the `textDocument/documentSymbol`
+type DocumentSymbolCapabilities =
+  { /// Whether document symbol supports dynamic registration.
+    DynamicRegistration: bool option
+
+    /// Specific capabilities for the `SymbolKind`.
+    SymbolKind: SymbolKindCapabilities option
+
+    /// The client supports hierarchical document symbols.
+    HierarchicalDocumentSymbolSupport: bool option }
+
+module CodeActionKind =
+  /// Empty kind.
+  let Empty = ""
+
+  /// Base kind for quickfix actions: 'quickfix'.
+  let QuickFix = "quickfix"
+
+  /// Base kind for refactoring actions: 'refactor'.
+  let Refactor = "refactor"
+
+  /// Base kind for refactoring extraction actions: 'refactor.extract'.
+  ///
+  /// Example extract actions:
+  ///
+  /// - Extract method
+  /// - Extract function
+  /// - Extract variable
+  /// - Extract interface from class
+  /// - ...
+  let RefactorExtract = "refactor.extract"
+
+  /// Base kind for refactoring inline actions: 'refactor.inline'.
+  ///
+  /// Example inline actions:
+  ///
+  /// - Inline function
+  /// - Inline variable
+  /// - Inline constant
+  /// - ...
+  let RefactorInline = "refactor.inline"
+
+  /// Base kind for refactoring rewrite actions: 'refactor.rewrite'.
+  ///
+  /// Example rewrite actions:
+  ///
+  /// - Convert JavaScript function to class
+  /// - Add or remove parameter
+  /// - Encapsulate field
+  /// - Make method static
+  /// - Move method to base class
+  /// - ...
+  let RefactorRewrite = "refactor.rewrite"
+
+  /// Base kind for source actions: `source`.
+  ///
+  /// Source code actions apply to the entire file.
+  let Source = "source"
+
+  ///
+  /// Base kind for an organize imports source action:
+  /// `source.organizeImports`.
+  ///
+  let SourceOrganizeImports = "source.organizeImports"
+
+  ///
+  /// Base kind for a 'fix all' source action: `source.fixAll`.
+  ///
+  /// 'Fix all' actions automatically fix errors that have a clear fix that
+  /// do not require user input. They should not suppress errors or perform
+  /// unsafe fixes such as generating new types or classes.
+  ///
+  /// @since 3.17.0
+  let SourceFixAll = "source.fixAll"
+
+type CodeActionClientCapabilityLiteralSupportCodeActionKind =
+  { /// The code action kind values the client supports. When this
+    /// property exists the client also guarantees that it will
+    /// handle values outside its set gracefully and falls back
+    /// to a default value when unknown.
+    /// See `CodeActionKind` for common values
+    ValueSet: string [] }
+
+type CodeActionClientCapabilityLiteralSupport =
+  { /// The code action kind is supported with the following value set.
+    CodeActionKind: CodeActionClientCapabilityLiteralSupportCodeActionKind }
+
+type CodeActionClientCapabilityResolveSupport =
+  { /// The properties that a client can resolve lazily.
+    Properties: string [] }
+
+/// capabilities specific to the `textDocument/codeAction`
+type CodeActionClientCapabilities =
+  { /// Whether document symbol supports dynamic registration.
+    DynamicRegistration: bool option
+
+    /// The client supports code action literals as a valid
+    /// response of the `textDocument/codeAction` request.
+    CodeActionLiteralSupport: CodeActionClientCapabilityLiteralSupport option
+
+    /// Whether code action supports the `isPreferred` property.
+    IsPreferredSupport: bool option
+
+    /// Whether code action supports the `disabled` property.
+    DisabledSupport: bool option
+
+    /// Whether code action supports the `data` property which is
+    /// preserved between a `textDocument/codeAction` and a
+    /// `codeAction/resolve` request.
+    DataSupport: bool option
+
+    /// Whether the client supports resolving additional code action
+    /// properties via a separate `codeAction/resolve` request.
+    ResolveSupport: CodeActionClientCapabilityResolveSupport option
+
+    /// Whether the client honors the change annotations in
+    /// text edits and resource operations returned via the
+    /// `CodeAction#edit` property by for example presenting
+    /// the workspace edit in the user interface and asking
+    /// for confirmation.
+    HonorsChangeAnnotations: bool option }
+
+[<RequireQualifiedAccess>]
+type DiagnosticTag =
+  /// Unused or unnecessary code.
+  ///
+  /// Clients are allowed to render diagnostics with this tag faded out instead of having
+  /// an error squiggle.
+  | Unnecessary = 1
+
+type DiagnosticTagSupport =
+  {
+
+    /// Represents the tags supported by the client
+    ValueSet: DiagnosticTag [] }
+
+/// Capabilities specific to `textDocument/publishDiagnostics`.
+type PublishDiagnosticsCapabilites =
+  {
+
+    /// Whether the clients accepts diagnostics with related information.
+    RelatedInformation: bool option
+
+    /// Client supports the tag property to provide meta data about a diagnostic.
+    TagSupport: DiagnosticTagSupport option }
+
+type FoldingRangeCapabilities =
+  { /// Whether implementation supports dynamic registration for folding range providers. If this is set to `true`
+    /// the client supports the new `(FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+    /// return value for the corresponding server capability as well.
+    DynamicRegistration: bool option
+    /// The maximum number of folding ranges that the client prefers to receive per document. The value serves as a
+    /// hint, servers are free to follow the limit.
+    RangeLimit: int option
+    /// If set, the client signals that it only supports folding complete lines. If set, client will
+    /// ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
+    LineFoldingOnly: bool option }
+
+type SemanticTokenFullRequestType =
+  { /// The client will send the `textDocument/semanticTokens/full/delta`
+    /// request if the server provides a corresponding handler.
+    Delta: bool option }
+
+type SemanticTokensRequests =
+  { /// The client will send the `textDocument/semanticTokens/range` request
+    /// if the server provides a corresponding handler.
+    Range: U2<bool, obj> option
+
+    /// The client will send the `textDocument/semanticTokens/full` request
+    /// if the server provides a corresponding handler.
+    Full: U2<bool, SemanticTokenFullRequestType> option }
+
+type TokenFormat = | Relative
+
+type SemanticTokensClientCapabilities =
+  { /// Whether implementation supports dynamic registration. If this is set to
+    /// `true` the client supports the new `(TextDocumentRegistrationOptions &
+    /// StaticRegistrationOptions)` return value for the corresponding server
+    /// capability as well.
+    DynamicRegistration: bool option
+
+    /// Which requests the client supports and might send to the server
+    /// depending on the server's capability. Please note that clients might not
+    /// show semantic tokens or degrade some of the user experience if a range
+    /// or full request is advertised by the client but not provided by the
+    /// server. If for example the client capability `requests.full` and
+    /// `request.range` are both set to true but the server only provides a
+    /// range provider the client might not render a minimap correctly or might
+    /// even decide to not show any semantic tokens at all.
+    Requests: SemanticTokensRequests
+
+    /// The token types that the client supports.
+    TokenTypes: string []
+
+    /// The token modifiers that the client supports.
+    TokenModifiers: string []
+
+    /// The formats the clients supports.
+    Formats: TokenFormat []
+
+    /// Whether the client supports tokens that can overlap each other.
+    OverlappingTokenSupport: bool option
+
+    /// Whether the client supports tokens that can span multiple lines.
+    MultilineTokenSupport: bool option }
+
+/// Text document specific client capabilities.
+type TextDocumentClientCapabilities =
+  { Synchronization: SynchronizationCapabilities option
+
+    /// Capabilities specific to `textDocument/publishDiagnostics`.
+    PublishDiagnostics: PublishDiagnosticsCapabilites
+
+    /// Capabilities specific to the `textDocument/completion`
+    Completion: CompletionCapabilities option
+
+    /// Capabilities specific to the `textDocument/hover`
+    Hover: HoverCapabilities option
+
+    /// Capabilities specific to the `textDocument/signatureHelp`
+    SignatureHelp: SignatureHelpCapabilities option
+
+    /// Capabilities specific to the `textDocument/references`
+    References: DynamicCapabilities option
+
+    /// Whether document highlight supports dynamic registration.
+    DocumentHighlight: DynamicCapabilities option
+
+    /// Capabilities specific to the `textDocument/documentSymbol`
+    DocumentSymbol: DocumentSymbolCapabilities option
+
+    /// Capabilities specific to the `textDocument/formatting`
+    Formatting: DynamicCapabilities option
+
+    /// Capabilities specific to the `textDocument/rangeFormatting`
+    RangeFormatting: DynamicCapabilities option
+
+    /// Capabilities specific to the `textDocument/onTypeFormatting`
+    OnTypeFormatting: DynamicCapabilities option
+
+    /// Capabilities specific to the `textDocument/definition`
+    Definition: DynamicCapabilities option
+
+    /// Capabilities specific to the `textDocument/codeAction`
+    CodeAction: CodeActionClientCapabilities option
+
+    /// Capabilities specific to the `textDocument/codeLens`
+    CodeLens: DynamicCapabilities option
+
+    /// Capabilities specific to the `textDocument/documentLink`
+    DocumentLink: DynamicCapabilities option
+
+    /// Capabilities specific to the `textDocument/rename`
+    Rename: DynamicCapabilities option
+
+    /// Capabilities for the `textDocument/foldingRange`
+    FoldingRange: FoldingRangeCapabilities option
+
+    /// Capabilities for the `textDocument/selectionRange`
+    SelectionRange: DynamicCapabilities option
+
+    /// Capabilities specific to the various semantic token requests.
+    /// @since 3.16.0
+    SemanticTokens: SemanticTokensClientCapabilities option }
+
+type ClientCapabilities =
+  { /// Workspace specific client capabilities.
+    Workspace: WorkspaceClientCapabilities option
+
+    /// Text document specific client capabilities.
+    TextDocument: TextDocumentClientCapabilities option
+
+    /// Experimental client capabilities.
+    Experimental: JToken option }
+
+type WorkspaceFolder =
+  { /// The associated URI for this workspace folder.
+    Uri: DocumentUri
+
+    /// The name of the workspace folder. Defaults to the
+    /// uri's basename.
+    Name: string }
+
+type ClientInfo = { Name: string; Version: string option }
+
+type InitializeParams =
+  { ProcessId: int option
+    /// Information about the client.
+    /// @since 3.15.0
+    ClientInfo: ClientInfo option
+    RootPath: string option
+    RootUri: string option
+    InitializationOptions: JToken option
+    Capabilities: ClientCapabilities option
+    trace: string option
+    /// The workspace folders configured in the client when the server starts.
+    /// This property is only available if the client supports workspace folders.
+    /// It can be `null` if the client supports workspace folders but none are configured.
+    /// @since 3.6.0
+    WorkspaceFolders: WorkspaceFolder [] option }
+
+type InitializedParams() =
+  class
+  end
+
+/// Completion options.
+type CompletionOptions =
+  { /// The server provides support to resolve additional information for a completion item.
+    ResolveProvider: bool option
+
+    /// The characters that trigger completion automatically.
+    TriggerCharacters: char [] option
+
+    /// The list of all possible characters that commit a completion.
+    /// This field can be used if clients don't support individual commit
+    /// characters per completion item.
+    ///
+    /// See `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`.
+    ///
+    /// If a server provides both `allCommitCharacters` and commit characters
+    /// on an individual completion item, the ones on the completion item win.
+    AllCommitCharacters: char [] option }
+
+/// Signature help options.
+type SignatureHelpOptions =
+  { /// The characters that trigger signature help automatically.
+    TriggerCharacters: char [] option
+    /// List of characters that re-trigger signature help.
+    ///
+    /// These trigger characters are only active when signature help is already showing.
+    /// All trigger characters are also counted as re-trigger characters.
+    RetriggerCharacters: char [] option }
+
+/// Code action options.
+type CodeActionOptions =
+  { /// CodeActionKinds that this server may return.
+    ///
+    /// The list of kinds may be generic, such as `CodeActionKind.Refactor`,
+    /// or the server may list out every specific kind they provide.
+    CodeActionKinds: string [] option
+
+    /// The server provides support to resolve additional
+    /// information for a code action.
+    ResolveProvider: bool option }
+
+/// Code Lens options.
+type CodeLensOptions =
+  { /// Code lens has a resolve provider as well.
+    ResolveProvider: bool option }
+
+/// Format document on type options
+type DocumentOnTypeFormattingOptions =
+  { /// A character on which formatting should be triggered, like `}`.
+    FirstTriggerCharacter: char
+
+    /// More trigger characters.
+    MoreTriggerCharacter: char [] option }
+
+/// Document link options
+type DocumentLinkOptions =
+  { /// Document links have a resolve provider as well.
+    ResolveProvider: bool option }
+
+/// Execute command options.
+type ExecuteCommandOptions =
+  { /// The commands to be executed on the server
+    commands: string [] option }
+
+/// Save options.
+type SaveOptions =
+  { /// The client is supposed to include the content on save.
+    IncludeText: bool option }
+
+type TextDocumentSyncOptions =
+  { /// Open and close notifications are sent to the server.
+    OpenClose: bool option
+
+    /// Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+    /// and TextDocumentSyncKind.Incremental.
+    Change: TextDocumentSyncKind option
+
+    /// Will save notifications are sent to the server.
+    WillSave: bool option
+
+    /// Will save wait until requests are sent to the server.
+    WillSaveWaitUntil: bool option
+
+    /// Save notifications are sent to the server.
+    Save: SaveOptions option }
+  static member Default =
+    { OpenClose = None
+      Change = None
+      WillSave = None
+      WillSaveWaitUntil = None
+      Save = None }
+
+type SemanticTokensLegend =
+  { /// The token types a server uses.
+    TokenTypes: string []
+    /// The token modifiers a server uses.
+    TokenModifiers: string [] }
+
+type SemanticTokenFullOptions =
+  { /// The server supports deltas for full documents.
+    Delta: bool option }
+
+type SemanticTokensOptions =
+  { /// The legend used by the server
+    Legend: SemanticTokensLegend
+
+    /// Server supports providing semantic tokens for a specific range of a document.
+    Range: U2<bool, obj> option
+
+    /// Server supports providing semantic tokens for a full document.
+    Full: U2<bool, SemanticTokenFullOptions> option }
+
+type WorkspaceFoldersServerCapabilities =
+  { /// The server has support for workspace folders.
+    Supported: bool option
+    /// Whether the server wants to receive workspace folder change notifications.
+    /// NOTE: the spec allows a string value here too. Good opportunity for further modeling.
+    ChangeNotifications: bool option }
+  static member Default = { Supported = None; ChangeNotifications = None }
+
+module FileOperationPatternKind =
+  let File = "file"
+  let Folder = "folder"
+
+type FileOperationPatternOptions =
+  { /// The pattern should be matched ignoring casing.
+    IgnoreCase: bool option }
+  static member Default = { IgnoreCase = None }
+
+/// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileOperationPattern.
+type FileOperationPattern =
+  { Glob: string
+    /// Whether to match files or folders with this pattern. Matches both if undefined.
+    /// See FileOperationPatternKind for allowed values
+    Matches: string option
+    /// Additional options used during matching
+    Options: FileOperationPatternOptions option }
+
+type FileOperationFilter =
+  { /// A Uri like `file` or `untitled`.
+    Scheme: string option
+    /// The actual file operation pattern.
+    Pattern: FileOperationPattern }
+
+type FileOperationRegistrationOptions = { Filters: FileOperationFilter [] }
+
+/// The types of workspace-level file notifications the server is interested in.
+type WorkspaceFileOperationsServerCapabilities =
+  { DidCreate: FileOperationRegistrationOptions option
+    WillCreate: FileOperationRegistrationOptions option
+    DidRename: FileOperationRegistrationOptions option
+    WillRename: FileOperationRegistrationOptions option
+    DidDelete: FileOperationRegistrationOptions option
+    WillDelete: FileOperationRegistrationOptions option }
+  static member Default =
+    { DidCreate = None
+      WillCreate = None
+      DidRename = None
+      WillRename = None
+      DidDelete = None
+      WillDelete = None }
+
+type WorkspaceServerCapabilities =
+  { /// The server supports workspace folder.
+    /// @since 3.6.0
+    WorkspaceFolders: WorkspaceFoldersServerCapabilities option
+    /// The server is interested in file notifications/requests.
+    /// @since 3.16.0
+    FileOperations: WorkspaceFileOperationsServerCapabilities option }
+  static member Default = { WorkspaceFolders = None; FileOperations = None }
+
+type ServerCapabilities =
+  { /// Defines how text documents are synced. Is either a detailed structure defining each notification or
+    /// for backwards compatibility the TextDocumentSyncKind number.
+    TextDocumentSync: TextDocumentSyncOptions option
+
+    /// The server provides hover support.
+    HoverProvider: bool option
+
+    /// The server provides completion support.
+    CompletionProvider: CompletionOptions option
+
+    /// The server provides signature help support.
+    SignatureHelpProvider: SignatureHelpOptions option
+
+    /// The server provides goto definition support.
+    DefinitionProvider: bool option
+
+    ///The server provides Goto Implementation support
+    ImplementationProvider: bool option
+
+    /// The server provides goto type definition support.
+    TypeDefinitionProvider: bool option
+
+    /// The server provides find references support.
+    ReferencesProvider: bool option
+
+    /// The server provides document highlight support.
+    DocumentHighlightProvider: bool option
+
+    /// The server provides document symbol support.
+    DocumentSymbolProvider: bool option
+
+    /// The server provides workspace symbol support.
+    WorkspaceSymbolProvider: bool option
+
+    /// The server provides code actions.
+    CodeActionProvider: CodeActionOptions option
+
+    /// The server provides code lens.
+    CodeLensProvider: CodeLensOptions option
+
+    /// The server provides document formatting.
+    DocumentFormattingProvider: bool option
+
+    /// The server provides document range formatting.
+    DocumentRangeFormattingProvider: bool option
+
+    /// The server provides document formatting on typing.
+    DocumentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions option
+
+    /// The server provides rename support.
+    RenameProvider: bool option
+
+    /// The server provides document link support.
+    DocumentLinkProvider: DocumentLinkOptions option
+
+    /// The server provides execute command support.
+    ExecuteCommandProvider: ExecuteCommandOptions option
+
+    /// Experimental server capabilities.
+    Experimental: JToken option
+
+    /// The server provides folding provider support.
+    /// @since 3.10.0
+    FoldingRangeProvider: bool option
+
+    SelectionRangeProvider: bool option
+
+    SemanticTokensProvider: SemanticTokensOptions option
+
+    /// Workspace specific server capabilities.
+    Workspace: WorkspaceServerCapabilities option
+
+   }
+  static member Default =
+    { HoverProvider = None
+      TextDocumentSync = None
+      CompletionProvider = None
+      SignatureHelpProvider = None
+      DefinitionProvider = None
+      TypeDefinitionProvider = None
+      ImplementationProvider = None
+      ReferencesProvider = None
+      DocumentHighlightProvider = None
+      DocumentSymbolProvider = None
+      WorkspaceSymbolProvider = None
+      CodeActionProvider = None
+      CodeLensProvider = None
+      DocumentFormattingProvider = None
+      DocumentRangeFormattingProvider = None
+      DocumentOnTypeFormattingProvider = None
+      RenameProvider = None
+      DocumentLinkProvider = None
+      ExecuteCommandProvider = None
+      Experimental = None
+      FoldingRangeProvider = None
+      SelectionRangeProvider = None
+      SemanticTokensProvider = None
+      Workspace = None }
+
+type InitializeResult =
+  { Capabilities: ServerCapabilities }
+  static member Default = { Capabilities = ServerCapabilities.Default }
+
+/// A workspace edit represents changes to many resources managed in the workspace.
+/// The edit should either provide `changes` or `documentChanges`. If the client can handle versioned document
+/// edits and if `documentChanges` are present, the latter are preferred over `changes`.
+type WorkspaceEdit =
+  { /// Holds changes to existing resources.
+    Changes: Map<string, TextEdit []> option
+
+    /// An array of `TextDocumentEdit`s to express changes to n different text documents
+    /// where each text document edit addresses a specific version of a text document.
+    /// Whether a client supports versioned document edits is expressed via
+    /// `WorkspaceClientCapabilities.workspaceEdit.documentChanges`.
+    DocumentChanges: TextDocumentEdit [] option }
+  static member DocumentChangesToChanges(edits: TextDocumentEdit []) =
+    edits
+    |> Array.map (fun edit -> edit.TextDocument.Uri.ToString(), edit.Edits)
+    |> Map.ofArray
+
+  static member CanUseDocumentChanges(capabilities: ClientCapabilities) =
+    (capabilities.Workspace
+     |> Option.bind (fun x -> x.WorkspaceEdit)
+     |> Option.bind (fun x -> x.DocumentChanges)) = Some true
+
+  static member Create(edits: TextDocumentEdit [], capabilities: ClientCapabilities) =
+    if WorkspaceEdit.CanUseDocumentChanges(capabilities) then
+      { Changes = None; DocumentChanges = Some edits }
+    else
+      { Changes = Some(WorkspaceEdit.DocumentChangesToChanges edits)
+        DocumentChanges = None }
+
+type MessageType =
+  | Error = 1
+  | Warning = 2
+  | Info = 3
+  | Log = 4
+
+type LogMessageParams = { Type: MessageType; Message: string }
+
+type ShowMessageParams = { Type: MessageType; Message: string }
+
+type MessageActionItem =
+  { /// A short title like 'Retry', 'Open Log' etc.
+    Title: string }
+
+type ShowMessageRequestParams =
+  { /// The message type.
+    Type: MessageType
+
+    /// The actual message
+    Message: string
+
+    /// The message action items to present.
+    Actions: MessageActionItem [] option }
+
+/// General parameters to register for a capability.
+type Registration =
+  { /// The id used to register the request. The id can be used to deregister
+    /// the request again.
+    Id: string
+
+    /// The method / capability to register for.
+    Method: string
+
+    /// Options necessary for the registration.
+    RegisterOptions: JToken option }
+
+type RegistrationParams = { Registrations: Registration [] }
+
+type ITextDocumentRegistrationOptions =
+  /// A document selector to identify the scope of the registration. If set to null
+  /// the document selector provided on the client side will be used.
+  abstract member DocumentSelector: DocumentSelector option
+
+/// General parameters to unregister a capability.
+type Unregistration =
+  { /// The id used to unregister the request or notification. Usually an id
+    /// provided during the register request.
+    Id: string
+
+    /// The method / capability to unregister for.
+    Method: string }
+
+type UnregistrationParams = { Unregisterations: Unregistration [] }
+
+type FileChangeType =
+  | Created = 1
+  | Changed = 2
+  | Deleted = 3
+
+/// An event describing a file change.
+type FileEvent =
+  { /// The file's URI.
+    Uri: DocumentUri
+
+    /// The change type.
+    Type: FileChangeType }
+
+type DidChangeWatchedFilesParams =
+  { /// The actual file events.
+    Changes: FileEvent [] }
+
+/// The workspace folder change event.
+type WorkspaceFoldersChangeEvent =
+  { /// The array of added workspace folders
+    Added: WorkspaceFolder []
+
+    /// The array of the removed workspace folders
+    Removed: WorkspaceFolder [] }
+
+type DidChangeWorkspaceFoldersParams =
+  { /// The actual workspace folder change event.
+    Event: WorkspaceFoldersChangeEvent }
+
+type DidChangeConfigurationParams =
+  { /// The actual changed settings
+    Settings: JToken }
+
+type ConfigurationItem =
+  { /// The scope to get the configuration section for.
+    ScopeUri: string option
+
+    /// The configuration section asked for.
+    Section: string option }
+
+type ConfigurationParams = { items: ConfigurationItem [] }
+
+/// The parameters of a Workspace Symbol Request.
+type WorkspaceSymbolParams =
+  { /// A non-empty query string
+    Query: string }
+
+type ExecuteCommandParams =
+  { /// The identifier of the actual command handler.
+    Command: string
+    /// Arguments that the command should be invoked with.
+    Arguments: JToken [] option }
+
+type ApplyWorkspaceEditParams =
+  { /// An optional label of the workspace edit. This label is
+    /// presented in the user interface for example on an undo
+    /// stack to undo the workspace edit.
+    Label: string option
+
+    /// The edits to apply.
+    Edit: WorkspaceEdit }
+
+type ApplyWorkspaceEditResponse =
+  { /// Indicates whether the edit was applied or not.
+    Applied: bool }
+
+/// Represents reasons why a text document is saved.
+type TextDocumentSaveReason =
+  /// Manually triggered, e.g. by the user pressing save, by starting debugging,
+  /// or by an API call.
+  | Manual = 1
+
+  /// Automatic after a delay.
+  | AfterDelay = 2
+
+  /// When the editor lost focus.
+  | FocusOut = 3
+
+/// The parameters send in a will save text document notification.
+type WillSaveTextDocumentParams =
+  { /// The document that will be saved.
+    TextDocument: TextDocumentIdentifier
+
+    /// The 'TextDocumentSaveReason'.
+    Reason: TextDocumentSaveReason }
+
+type DidSaveTextDocumentParams =
+  { /// The document that was saved.
+    TextDocument: TextDocumentIdentifier
+
+    /// Optional the content when saved. Depends on the includeText value
+    /// when the save notification was requested.
+    Text: string option }
+
+type DidCloseTextDocumentParams =
+  { /// The document that was closed.
+    TextDocument: TextDocumentIdentifier }
+
+/// Value-object describing what options formatting should use.
+type FormattingOptions() =
+  /// Size of a tab in spaces.
+  member val TabSize: int = 0 with get, set
+
+  /// Prefer spaces over tabs.
+  member val InsertSpaces: bool = false with get, set
+
+  /// Further properties.
+  [<JsonExtensionData>]
+  member val AdditionalData: System.Collections.Generic.IDictionary<string, JToken> =
+    new System.Collections.Generic.Dictionary<_, _>() :> _ with get, set
+
+type DocumentFormattingParams =
+  { /// The document to format.
+    TextDocument: TextDocumentIdentifier
+
+    /// The format options.
+    Options: FormattingOptions }
+
+type DocumentRangeFormattingParams =
+  { /// The document to format.
+    TextDocument: TextDocumentIdentifier
+
+    /// The range to format
+    Range: Range
+
+    /// The format options
+    Options: FormattingOptions }
+
+type DocumentOnTypeFormattingParams =
+  { /// The document to format.
+    TextDocument: TextDocumentIdentifier
+
+    /// The position at which this request was sent.
+    Position: Position
+
+    /// The character that has been typed.
+    Ch: char
+
+    /// The format options.
+    Options: FormattingOptions }
+
+type DocumentSymbolParams =
+  { /// The text document.
+    TextDocument: TextDocumentIdentifier }
+
+type ITextDocumentPositionParams =
+  /// The text document.
+  abstract member TextDocument: TextDocumentIdentifier
+  /// The position inside the text document.
+  abstract member Position: Position
+
+type TextDocumentPositionParams =
+  { /// The text document.
+    TextDocument: TextDocumentIdentifier
+    /// The position inside the text document.
+    Position: Position }
+  interface ITextDocumentPositionParams with
+    member this.TextDocument = this.TextDocument
+    member this.Position = this.Position
+
+type ReferenceContext =
+  { /// Include the declaration of the current symbol.
+    IncludeDeclaration: bool }
+
+type ReferenceParams =
+  { /// The text document.
+    TextDocument: TextDocumentIdentifier
+    /// The position inside the text document.
+    Position: Position
+    Context: ReferenceContext }
+  interface ITextDocumentPositionParams with
+    member this.TextDocument = this.TextDocument
+    member this.Position = this.Position
+
+/// A `MarkupContent` literal represents a string value which content is interpreted base on its
+/// kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
+///
+/// If the kind is `markdown` then the value can contain fenced code blocks like in GitHub issues.
+/// See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+///
+/// Here is an example how such a string can be constructed using JavaScript / TypeScript:
+/// ```ts
+/// let markdown: MarkdownContent = {
+///     kind: MarkupKind.Markdown,
+///     value: [
+///         '# Header',
+///         'Some text',
+///         '```typescript',
+///         'someCode();',
+///         '```'
+///     ].join('\n')
+/// };
+/// ```
+///
+/// *Please Note* that clients might sanitize the return markdown. A client could decide to
+/// remove HTML from the markdown to avoid script execution.
+type MarkupContent =
+  { /// The type of the Markup
+    Kind: string
+
+    // The content itself
+    Value: string }
+
+type MarkedStringData = { Language: string; Value: string }
+
+[<ErasedUnion>]
+[<RequireQualifiedAccess>]
+type MarkedString =
+  | String of string
+  | WithLanguage of MarkedStringData
+
+let plaintext s = { Kind = MarkupKind.PlainText; Value = s }
+let markdown s = { Kind = MarkupKind.Markdown; Value = s }
+
+[<ErasedUnion>]
+type HoverContent =
+  | MarkedString of MarkedString
+  | MarkedStrings of MarkedString []
+  | MarkupContent of MarkupContent
+
+/// The result of a hover request.
+type Hover =
+  { /// The hover's content
+    Contents: HoverContent
+
+    /// An optional range is a range inside a text document
+    /// that is used to visualize a hover, e.g. by changing the background color.
+    Range: Range option }
+
+/// An item to transfer a text document from the client to the server.
+type TextDocumentItem =
+  { /// The text document's URI.
+    Uri: DocumentUri
+
+    /// The text document's language identifier.
+    LanguageId: string
+
+    /// The version number of this document (it will increase after each
+    /// change, including undo/redo).
+    Version: int
+
+    /// The content of the opened text document.
+    Text: string }
+
+type DidOpenTextDocumentParams =
+  { /// The document that was opened.
+    TextDocument: TextDocumentItem }
+
+/// An event describing a change to a text document. If range and rangeLength are omitted
+/// the new text is considered to be the full content of the document.
+type TextDocumentContentChangeEvent =
+  { /// The range of the document that changed.
+    Range: Range option
+
+    /// The length of the range that got replaced.
+    RangeLength: int option
+
+    /// The new text of the range/document.
+    Text: string }
+
+type DidChangeTextDocumentParams =
+  { /// The document that did change. The version number points
+    /// to the version after all provided content changes have
+    /// been applied.
+    TextDocument: VersionedTextDocumentIdentifier
+
+    /// The actual content changes. The content changes describe single state changes
+    /// to the document. So if there are two content changes c1 and c2 for a document
+    /// in state S10 then c1 move the document to S11 and c2 to S12.
+    ContentChanges: TextDocumentContentChangeEvent [] }
+
+[<Flags>]
+type WatchKind =
+  | Create = 1
+  | Change = 2
+  | Delete = 4
+
+type FileSystemWatcher =
+  { /// The  glob pattern to watch
+    GlobPattern: string
+
+    /// The kind of events of interest. If omitted it defaults
+    /// to WatchKind.Create | WatchKind.Change | WatchKind.Delete
+    /// which is 7.
+    Kind: WatchKind option }
+
+/// Describe options to be used when registered for text document change events.
+type DidChangeWatchedFilesRegistrationOptions =
+  { /// The watchers to register.
+    Watchers: FileSystemWatcher [] }
+
+/// How a completion was triggered
+type CompletionTriggerKind =
+  /// Completion was triggered by typing an identifier (24x7 code
+  /// complete), manual invocation (e.g Ctrl+Space) or via API.
+  | Invoked = 1
+  /// Completion was triggered by a trigger character specified by
+  /// the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+  | TriggerCharacter = 2
+
+type CompletionContext =
+  { ///  How the completion was triggered.
+    triggerKind: CompletionTriggerKind
+
+    /// The trigger character (a single character) that has trigger code complete.
+    /// Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+    triggerCharacter: char option }
+
+type CompletionParams =
+  { /// The text document.
+    TextDocument: TextDocumentIdentifier
+
+    /// The position inside the text document.
+    Position: Position
+
+    /// The completion context. This is only available it the client specifies
+    /// to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
+    Context: CompletionContext option }
+  interface ITextDocumentPositionParams with
+    member this.TextDocument = this.TextDocument
+    member this.Position = this.Position
+
+/// Represents a reference to a command. Provides a title which will be used to represent a command in the UI.
+/// Commands are identified by a string identifier. The protocol currently doesn't specify a set of well-known
+/// commands. So executing a command requires some tool extension code.
+type Command =
+  { /// Title of the command, like `save`.
+    Title: string
+
+    /// The identifier of the actual command handler.
+    Command: string
+
+    /// Arguments that the command handler should be
+    /// invoked with.
+    Arguments: JToken [] option }
+
+/// Defines whether the insert text in a completion item should be interpreted as
+/// plain text or a snippet.
+type InsertTextFormat =
+  /// The primary text to be inserted is treated as a plain string.
+  | PlainText = 1
+  /// The primary text to be inserted is treated as a snippet.
+  ///
+  /// A snippet can define tab stops and placeholders with `$1`, `$2`
+  /// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+  /// the end of the snippet. Placeholders with equal identifiers are linked,
+  /// that is typing in one will update others too.
+  | Snippet = 2
+
+[<ErasedUnion>]
+[<RequireQualifiedAccess>]
+type Documentation =
+  | String of string
+  | Markup of MarkupContent
+
+type CompletionItem =
+  { /// The label of this completion item. By default
+    /// also the text that is inserted when selecting
+    /// this completion.
+    Label: string
+
+    /// The kind of this completion item. Based of the kind
+    /// an icon is chosen by the editor.
+    Kind: CompletionItemKind option
+
+    /// A human-readable string with additional information
+    /// about this item, like type or symbol information.
+    Detail: string option
+
+    /// A human-readable string that represents a doc-comment.
+    Documentation: Documentation option
+
+    /// A string that should be used when comparing this item
+    /// with other items. When `falsy` the label is used.
+    SortText: string option
+
+    /// A string that should be used when filtering a set of
+    /// completion items. When `falsy` the label is used.
+    FilterText: string option
+
+    /// A string that should be inserted into a document when selecting
+    /// this completion. When `falsy` the label is used.
+    ///
+    /// The `insertText` is subject to interpretation by the client side.
+    /// Some tools might not take the string literally. For example
+    /// VS Code when code complete is requested in this example `con<cursor position>`
+    /// and a completion item with an `insertText` of `console` is provided it
+    /// will only insert `sole`. Therefore it is recommended to use `textEdit` instead
+    /// since it avoids additional client side interpretation.
+    ///
+    /// @deprecated Use textEdit instead.
+    InsertText: string option
+
+    /// The format of the insert text. The format applies to both the `insertText` property
+    /// and the `newText` property of a provided `textEdit`.
+    InsertTextFormat: InsertTextFormat option
+
+    /// An edit which is applied to a document when selecting this completion. When an edit is provided the value of
+    /// `insertText` is ignored.
+    ///
+    /// *Note:* The range of the edit must be a single line range and it must contain the position at which completion
+    /// has been requested.
+    TextEdit: TextEdit option
+
+    /// An optional array of additional text edits that are applied when
+    /// selecting this completion. Edits must not overlap with the main edit
+    /// nor with themselves.
+    AdditionalTextEdits: TextEdit [] option
+
+    /// An optional set of characters that when pressed while this completion is active will accept it first and
+    /// then type that character. *Note* that all commit characters should have `length=1` and that superfluous
+    /// characters will be ignored.
+    CommitCharacters: char [] option
+
+    /// An optional command that is executed *after* inserting this completion. *Note* that
+    /// additional modifications to the current document should be described with the
+    /// additionalTextEdits-property.
+    Command: Command option
+
+    /// An data entry field that is preserved on a completion item between
+    /// a completion and a completion resolve request.
+    Data: JToken option }
+  static member Create(label: string) =
+    { Label = label
+      Kind = None
+      Detail = None
+      Documentation = None
+      SortText = None
+      FilterText = None
+      InsertText = None
+      InsertTextFormat = None
+      TextEdit = None
+      AdditionalTextEdits = None
+      CommitCharacters = None
+      Command = None
+      Data = None }
+
+type CompletionList =
+  { /// This list it not complete. Further typing should result in recomputing
+    /// this list.
+    IsIncomplete: bool
+
+    /// The completion items.
+    Items: CompletionItem [] }
+
+[<ErasedUnion>]
+[<RequireQualifiedAccess>]
+type DiagnosticCode =
+  | Number of int
+  | String of string
+
+[<RequireQualifiedAccess>]
+type DiagnosticSeverity =
+  ///  Reports an error.
+  | Error = 1
+  ///  Reports a warning.
+  | Warning = 2
+  ///  Reports an information.
+  | Information = 3
+  ///  Reports a hint.
+  | Hint = 4
+
+/// Represents a related message and source code location for a diagnostic. This should be
+/// used to point to code locations that cause or related to a diagnostics, e.g when duplicating
+/// a symbol in a scope.
+type DiagnosticRelatedInformation = { Location: Location; Message: string }
+
+// Structure to capture a description for an error code.
+type CodeDescription =
+  {
+    // An URI to open with more information about the diagnostic error.
+    Href: Uri option }
+
+/// Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid in the
+/// scope of a resource.
+[<DebuggerDisplay("{DebuggerDisplay}")>]
+type Diagnostic =
+  { /// The range at which the message applies.
+    Range: Range
+
+    /// The diagnostic's severity. Can be omitted. If omitted it is up to the
+    /// client to interpret diagnostics as error, warning, info or hint.
+    Severity: DiagnosticSeverity option
+
+    /// The diagnostic's code. Can be omitted.
+    Code: string option
+    /// An optional property to describe the error code.
+    CodeDescription: CodeDescription option
+
+    /// A human-readable string describing the source of this
+    /// diagnostic, e.g. 'typescript' or 'super lint'.
+    Source: string
+
+    /// The diagnostic's message.
+    Message: string
+    RelatedInformation: DiagnosticRelatedInformation [] option
+    Tags: DiagnosticTag [] option
+    /// A data entry field that is preserved between a
+    /// `textDocument/publishDiagnostics` notification and
+    /// `textDocument/codeAction` request.
+    Data: obj option
+
+   }
+  [<DebuggerBrowsable(DebuggerBrowsableState.Never); JsonIgnore>]
+  member x.DebuggerDisplay =
+    $"[{defaultArg x.Severity DiagnosticSeverity.Error}] ({x.Range.DebuggerDisplay}) {x.Message} ({defaultArg x.Code String.Empty})"
+
+type PublishDiagnosticsParams =
+  { /// The URI for which diagnostic information is reported.
+    Uri: DocumentUri
+
+    /// An array of diagnostic information items.
+    Diagnostics: Diagnostic [] }
+
+type CodeActionDisabled =
+  { /// Human readable description of why the code action is currently
+    /// disabled.
+    ///
+    /// This is displayed in the code actions UI.
+    Reason: string }
+
+/// A code action represents a change that can be performed in code, e.g. to fix a problem or
+/// to refactor code.
+///
+/// A CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed.
+type CodeAction =
+  {
+
+    /// A short, human-readable, title for this code action.
+    Title: string
+
+    /// The kind of the code action.
+    /// Used to filter code actions.
+    Kind: string option
+
+    /// The diagnostics that this code action resolves.
+    Diagnostics: Diagnostic [] option
+
+    /// Marks this as a preferred action. Preferred actions are used by the
+    /// `auto fix` command and can be targeted by keybindings.
+    ///
+    /// * A quick fix should be marked preferred if it properly addresses the
+    /// underlying error. A refactoring should be marked preferred if it is the
+    /// most reasonable choice of actions to take.
+    ///
+    /// * @since 3.15.0
+    IsPreferred: bool option
+
+    /// Marks that the code action cannot currently be applied.
+    ///
+    /// Clients should follow the following guidelines regarding disabled code
+    /// actions:
+    ///
+    /// - Disabled code actions are not shown in automatic lightbulbs code
+    /// action menus.
+    ///
+    /// - Disabled actions are shown as faded out in the code action menu when
+    /// the user request a more specific type of code action, such as
+    /// refactorings.
+    ///
+    /// - If the user has a keybinding that auto applies a code action and only
+    /// a disabled code actions are returned, the client should show the user
+    /// an error message with `reason` in the editor.
+    ///
+    /// @since 3.16.0
+    Disabled: CodeActionDisabled option
+
+    /// The workspace edit this code action performs.
+    Edit: WorkspaceEdit option
+
+    /// A command this code action executes. If a code action
+    /// provides an edit and a command, first the edit is
+    /// executed and then the command.
+    Command: Command option
+
+    /// A data entry field that is preserved on a code action between
+    /// a `textDocument/codeAction` and a `codeAction/resolve` request.
+    Data: obj option }
+
+[<ErasedUnion>]
+[<RequireQualifiedAccess>]
+type TextDocumentCodeActionResult =
+  | Commands of Command []
+  | CodeActions of CodeAction []
+
+type RenameParams =
+  { /// The document to rename.
+    TextDocument: TextDocumentIdentifier
+
+    /// The position at which this request was sent.
+    Position: Position
+
+    /// The new name of the symbol. If the given name is not valid the
+    /// request must return a **ResponseError** with an
+    /// appropriate message set.
+    NewName: string }
+  interface ITextDocumentPositionParams with
+    member this.TextDocument = this.TextDocument
+    member this.Position = this.Position
+
+[<ErasedUnion>]
+[<RequireQualifiedAccess>]
+type GotoResult =
+  | Single of Location
+  | Multiple of Location []
+
+/// A document highlight kind.
+[<RequireQualifiedAccess>]
+type DocumentHighlightKind =
+  /// A textual occurrence.
+  | Text = 1
+
+  /// Read-access of a symbol, like reading a variable.
+  | Read = 2
+
+  /// Write-access of a symbol, like writing to a variable.
+  | Write = 3
+
+/// A document highlight is a range inside a text document which deserves
+/// special attention. Usually a document highlight is visualized by changing
+/// the background color of its range.
+type DocumentHighlight =
+  { /// The range this highlight applies to.
+    Range: Range
+
+    /// The highlight kind, default is DocumentHighlightKind.Text.
+    Kind: DocumentHighlightKind option }
+
+type DocumentLinkParams =
+  { /// The document to provide document links for.
+    TextDocument: TextDocumentIdentifier }
+
+/// A document link is a range in a text document that links to an internal or external resource, like another
+/// text document or a web site.
+type DocumentLink =
+  { /// The range this link applies to.
+    Range: Range
+
+    /// The uri this link points to. If missing a resolve request is sent later.
+    Target: DocumentUri option }
+
+type DocumentColorParams =
+  { /// The text document.
+    TextDocument: TextDocumentIdentifier }
+
+/// Represents a color in RGBA space.
+type Color =
+  { /// The red component of this color in the range [0-1].
+    Red: float
+
+    /// The green component of this color in the range [0-1].
+    Green: float
+
+    /// The blue component of this color in the range [0-1].
+    Blue: float
+
+    /// The alpha component of this color in the range [0-1].
+    Alpha: float }
+
+type ColorInformation =
+  { /// The range in the document where this color appears.
+    Range: Range
+
+    /// The actual color value for this color range.
+    Color: Color }
+
+type ColorPresentationParams =
+  { /// The text document.
+    TextDocument: TextDocumentIdentifier
+
+    /// The color information to request presentations for.
+    ColorInfo: Color
+
+    /// The range where the color would be inserted. Serves as a context.
+    Range: Range }
+
+type ColorPresentation =
+  { /// The label of this color presentation. It will be shown on the color
+    /// picker header. By default this is also the text that is inserted when selecting
+    /// this color presentation.
+    Label: string
+
+    /// An edit which is applied to a document when selecting
+    /// this presentation for the color.  When `falsy` the label
+    /// is used.
+    TextEdit: TextEdit option
+
+    /// An optional array of additional text edits that are applied when
+    /// selecting this color presentation. Edits must not overlap with the main edit nor with themselves.
+    AdditionalTextEdits: TextEdit [] option }
+
+/// Contains additional diagnostic information about the context in which
+/// a code action is run.
+type CodeActionContext =
+  { /// An array of diagnostics.
+    Diagnostics: Diagnostic [] }
+
+/// Params for the CodeActionRequest
+type CodeActionParams =
+  { /// The document in which the command was invoked.
+    TextDocument: TextDocumentIdentifier
+
+    /// The range for which the command was invoked.
+    Range: Range
+
+    /// Context carrying additional information.
+    Context: CodeActionContext }
+
+type CodeLensParams =
+  { /// The document to request code lens for.
+    TextDocument: TextDocumentIdentifier }
+
+/// A code lens represents a command that should be shown along with
+/// source text, like the number of references, a way to run tests, etc.
+///
+/// A code lens is _unresolved_ when no command is associated to it. For performance
+/// reasons the creation of a code lens and resolving should be done in two stages.
+type CodeLens =
+  { /// The range in which this code lens is valid. Should only span a single line.
+    Range: Range
+
+    /// The command this code lens represents.
+    Command: Command option
+
+    /// A data entry field that is preserved on a code lens item between
+    /// a code lens and a code lens resolve request.
+    Data: JToken option }
+
+/// Represents a parameter of a callable-signature. A parameter can
+/// have a label and a doc-comment.
+type ParameterInformation =
+  { /// The label of this parameter. Will be shown in
+    /// the UI.
+    Label: string
+
+    /// The human-readable doc-comment of this parameter. Will be shown
+    /// in the UI but can be omitted.
+    Documentation: Documentation option }
+
+///Represents the signature of something callable. A signature
+/// can have a label, like a function-name, a doc-comment, and
+/// a set of parameters.
+type SignatureInformation =
+  { /// The label of this signature. Will be shown in
+    /// the UI.
+    Label: string
+
+    /// The human-readable doc-comment of this signature. Will be shown
+    /// in the UI but can be omitted.
+    Documentation: Documentation option
+
+    /// The parameters of this signature.
+    Parameters: ParameterInformation [] option }
+
+/// Signature help represents the signature of something
+/// callable. There can be multiple signature but only one
+/// active and only one active parameter.
+type SignatureHelp =
+  { /// One or more signatures.
+    Signatures: SignatureInformation []
+
+    /// The active signature. If omitted or the value lies outside the
+    /// range of `signatures` the value defaults to zero or is ignored if
+    /// `signatures.length === 0`. Whenever possible implementors should
+    /// make an active decision about the active signature and shouldn't
+    /// rely on a default value.
+    /// In future version of the protocol this property might become
+    /// mandatory to better express this.
+    ActiveSignature: int option
+
+    /// The active parameter of the active signature. If omitted or the value
+    /// lies outside the range of `signatures[activeSignature].parameters`
+    /// defaults to 0 if the active signature has parameters. If
+    /// the active signature has no parameters it is ignored.
+    /// In future version of the protocol this property might become
+    /// mandatory to better express the active parameter if the
+    /// active signature does have any.
+    ActiveParameter: int option }
+
+type SignatureHelpTriggerKind =
+  /// manually invoked via command
+  | Invoked = 1
+  /// trigger by a configured trigger character
+  | TriggerCharacter = 2
+  /// triggered by cursor movement or document content changing
+  | ContentChange = 3
+
+type SignatureHelpContext =
+  { /// action that caused signature help to be triggered
+    TriggerKind: SignatureHelpTriggerKind
+    /// character that caused signature help to be triggered. None when kind is not TriggerCharacter.
+    TriggerCharacter: char option
+    /// true if signature help was already showing when this was triggered
+    IsRetrigger: bool
+    /// the current active SignatureHelp
+    ActiveSignatureHelp: SignatureHelp option
+
+   }
+
+type SignatureHelpParams =
+  { /// the text document
+    TextDocument: TextDocumentIdentifier
+    /// the position inside the text document
+    Position: Position
+    /// Additional information about the context in which a signature help request was triggered.
+    Context: SignatureHelpContext option }
+  interface ITextDocumentPositionParams with
+    member this.TextDocument = this.TextDocument
+    member this.Position = this.Position
+
+type FoldingRangeParams =
+  { /// the document to generate ranges for
+    TextDocument: TextDocumentIdentifier }
+
+module FoldingRangeKind =
+  let Comment = "comment"
+  let Imports = "imports"
+  let Region = "region"
+
+type FoldingRange =
+  { /// The zero-based line number from where the folded range starts.
+    StartLine: int
+
+    /// The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
+    StartCharacter: int option
+
+    /// The zero-based line number where the folded range ends.
+    EndLine: int
+
+    /// The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
+    EndCharacter: int option
+
+    /// Describes the kind of the folding range such as 'comment' or 'region'. The kind
+    /// is used to categorize folding ranges and used by commands like 'Fold all comments'. See
+    /// [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+    Kind: string option }
+
+type SelectionRangeParams =
+  { /// The document to generate ranges for
+    TextDocument: TextDocumentIdentifier
+
+    /// The positions inside the text document.
+    Positions: Position [] }
+
+type SelectionRange =
+  { /// The range of this selection range.
+    Range: Range
+
+    /// The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
+    Parent: SelectionRange option }
+
+type SemanticTokensParams = { TextDocument: TextDocumentIdentifier }
+
+type SemanticTokensDeltaParams =
+  { TextDocument: TextDocumentIdentifier
+    /// The result id of a previous response. The result Id can either point to
+    /// a full response or a delta response depending on what was received last.
+    PreviousResultId: string }
+
+type SemanticTokensRangeParams = { TextDocument: TextDocumentIdentifier; Range: Range }
+
+type SemanticTokens =
+  { /// An optional result id. If provided and clients support delta updating
+    /// the client will include the result id in the next semantic token request.
+    /// A server can then instead of computing all semantic tokens again simply
+    /// send a delta.
+    ResultId: string option
+    Data: uint32 [] }
+
+type SemanticTokensEdit =
+  { /// The start offset of the edit.
+    Start: uint32
+
+    /// The count of elements to remove.
+    DeleteCount: uint32
+
+    /// The elements to insert.
+    Data: uint32 [] option }
+
+type SemanticTokensDelta =
+  { ResultId: string option
+
+    /// The semantic token edits to transform a previous result into a new result.
+    Edits: SemanticTokensEdit [] }
+
+/// Represents information on a file/folder create.
+///@since 3.16.0
+type FileCreate =
+  { /// A file:// URI for the location of the file/folder being created.
+    Uri: string }
+
+/// The parameters sent in notifications/requests for user-initiated creation of files.
+/// @since 3.16.0
+type CreateFilesParams =
+  { /// An array of all files/folders created in this operation.
+    Files: FileCreate [] }
+
+/// Represents information on a file/folder rename.
+/// @since 3.16.0
+type FileRename =
+  { /// A file:// URI for the original location of the file/folder being renamed.
+    OldUri: string
+    /// A file:// URI for the new location of the file/folder being renamed.
+    NewUri: string }
+
+/// The parameters sent in notifications/requests for user-initiated renames of files.
+/// @since 3.16.0
+type RenameFilesParams =
+  { /// An array of all files/folders renamed in this operation. When a folder is renamed,
+    /// only the folder will be included, and not its children.
+    Files: FileRename [] }
+
+/// Represents information on a file/folder create.
+///@since 3.16.0
+type FileDelete =
+  { /// A file:// URI for the location of the file/folder being deleted.
+    Uri: string }
+
+/// The parameters sent in notifications/requests for user-initiated deletes of files.
+/// @since 3.16.0
+type DeleteFilesParams =
+  { /// An array of all files/folders deleted in this operation.
+    Files: FileDelete [] }


### PR DESCRIPTION
The single file was getting a bit long in the tooth and so I split it up.

Now, 
* JsonRpc-specific types (request/response) are in the JsonRpc.fs file.
* LSP Type declarations are in Types.fs
* Client-based APIs are in Client.fs
* Server-based APIs are in Server.fs
* The low-level protocol bits, like JsonConverters for the specific types and the protocol routing, etc are in LanguageServerProtocol.fs

All files have been formatted with fantomas, format-on-save is enabled, and the fantomas tool is installed.

The goal here is to make review easier - if changes are mostly to types/client/server then it's easier to rubber-stamp. Changes to low-level protocol are much more scary :D
