### PR TITLE
[RFC] Workaround a VSCode bug that precludes the server from exiting

### DIFF
--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -243,11 +243,24 @@ module Server =
     let mutable quitReceived = false
     use quitSemaphore = new SemaphoreSlim(0, 1)
 
-    let onShutdown () = shutdownReceived <- true
+    let onShutdown () =
+      logger.trace (Log.setMessage "Shutdown received")
+      shutdownReceived <- true
+      // VSCode Language Client has a bug that causes it to NOT send an `exit` notification when stopping a server:
+      // https://github.com/microsoft/vscode-languageserver-node/pull/776 This may result in a bunch of zombie language
+      // servers just hanging around after a few reloads/restarts.  Although the fix was merged a while ago, the new
+      // client is yet to be released.  As a workaround let's forcefully exit after 10s after receiving a `shutdown`
+      // request.
+      task {
+        do! Task.Delay(10_000)
+        logger.trace (Log.setMessage "No `exit` notification within 10s after `shutdown` request. Exiting now.")
+        quitSemaphore.Release() |> ignore
+      } |> ignore
 
     jsonRpc.AddLocalRpcMethod("shutdown", Action(onShutdown))
 
     let onExit () =
+      logger.trace (Log.setMessage "Exit received")
       quitReceived <- true
       quitSemaphore.Release() |> ignore
 


### PR DESCRIPTION
VSCode language client doesn't properly send an exit notification to the server; so when the server is restarted or the window is reloaded currently running server turns into a zombie... and after a while we have a zombie party.

I see that FSAC has its own workaround where it tries to monitor the parent process. That solution is local to the actual server and doesn't require changes in the library.

Another solution is to add a bit of logic into the library which may not be as clean, but it'd relieve the servers from needing to re-invent a workaround to the bug.