### PR TITLE
Make `InlayHint` client capability optional

### DIFF
--- a/src/Types.fs
+++ b/src/Types.fs
@@ -772,7 +772,7 @@ type ClientCapabilities =
     /// Client workspace capabilities specific to inlay hints.
     ///
     /// @since 3.17.0
-    InlayHint: InlayHintWorkspaceClientCapabilities
+    InlayHint: InlayHintWorkspaceClientCapabilities option
 
     /// Experimental client capabilities.
     Experimental: JToken option }


### PR DESCRIPTION
It is optional according to the spec:
```
/**
 *Client workspace capabilities specific to inlay hints.
 *
 * @since 3.17.0
 */
inlayHint?: InlayHintWorkspaceClientCapabilities;
```