### PR TITLE
Add Deserialization for `ErasedUnion`s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
         with:
           global-json-file: global.json
       - name: Run build
-        run: dotnet build -c Release
+        run: dotnet build -c Release src
       - name: Run publish
-        run: dotnet pack -c Release -o release
+        run: dotnet pack -c Release -o release src
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Pack the library
-        run: dotnet pack -c Release -o release
+        run: dotnet pack -c Release -o release src
 
       - name: Get Changelog Entry
         id: changelog_reader

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 obj
 release
+BenchmarkDotNet.Artifacts

--- a/LanguageServerProtocol.sln
+++ b/LanguageServerProtocol.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Ionide.LanguageServerProtocol", "src\Ionide.LanguageServerProtocol.fsproj", "{CA3DF91E-B82C-4DFC-BDBC-CE383717E457}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Ionide.LanguageServerProtocol.Tests", "tests\Ionide.LanguageServerProtocol.Tests.fsproj", "{8E54FA2A-C7E4-4D70-AF23-7F8D56EB6B9C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{CA3DF91E-B82C-4DFC-BDBC-CE383717E457}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA3DF91E-B82C-4DFC-BDBC-CE383717E457}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA3DF91E-B82C-4DFC-BDBC-CE383717E457}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E54FA2A-C7E4-4D70-AF23-7F8D56EB6B9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E54FA2A-C7E4-4D70-AF23-7F8D56EB6B9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E54FA2A-C7E4-4D70-AF23-7F8D56EB6B9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E54FA2A-C7E4-4D70-AF23-7F8D56EB6B9C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="Types.fs" />
     <Compile Include="Client.fs" />
     <Compile Include="Server.fs" />
+    <Compile Include="JsonConverters.fs" />
     <Compile Include="LanguageServerProtocol.fs" />
     <None Include="../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -22,7 +22,7 @@
     <Compile Include="Types.fs" />
     <Compile Include="Client.fs" />
     <Compile Include="Server.fs" />
-    <Compile Include="JsonConverters.fs" />
+    <Compile Include="JsonUtils.fs" />
     <Compile Include="LanguageServerProtocol.fs" />
     <None Include="../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/JsonConverters.fs
+++ b/src/JsonConverters.fs
@@ -1,0 +1,164 @@
+module Ionide.LanguageServerProtocol.JsonConverters
+
+open Microsoft.FSharp.Reflection
+open Newtonsoft.Json
+open System
+open System.Collections.Concurrent
+open Ionide.LanguageServerProtocol.Types
+open Newtonsoft.Json.Linq
+
+let inline memorise (f: 'a -> 'b) : ('a -> 'b) =
+  let d = ConcurrentDictionary<'a, 'b>()
+  fun key -> d.GetOrAdd(key, f)
+
+//TODO: Cache stuff
+type ErasedUnionConverter() =
+  inherit JsonConverter()
+
+  let canConvert =
+    //todo: must be just one field! (or 0?)
+    memorise (fun t ->
+      FSharpType.IsUnion t
+      && (
+      // Union
+      t.GetCustomAttributes(typedefof<ErasedUnionAttribute>, false).Length > 0
+      ||
+      // Case
+      t.BaseType.GetCustomAttributes(typedefof<ErasedUnionAttribute>, false).Length > 0))
+
+  override __.CanConvert(t) = canConvert t
+
+  override __.WriteJson(writer, value, serializer) =
+    let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
+    // Must be exactly 1 field
+    // Deliberately fail here to signal incorrect usage
+    // (vs. CanConvert = false -> silent and serialization to `case` & `fields`)
+    match fields with
+    | [| unionField |] -> serializer.Serialize(writer, unionField)
+    | _ -> failwith $"Expected exactly one field for case `{value.GetType().Name}`, but were {fields.Length}"
+
+  override __.ReadJson(reader: JsonReader, t, _existingValue, serializer) =
+    let tryReadValue (json: JToken) (targetType: Type) =
+      //TODO: handle simple types without exception handling?
+      try
+        json.ToObject(targetType, serializer) |> Some
+      with
+      | _ -> None
+
+    let tryMakeUnionCase (json: JToken) (case: UnionCaseInfo) =
+      match case.GetFields() with
+      | [| field |] ->
+        let ty = field.PropertyType
+
+        match tryReadValue json ty with
+        | None -> None
+        | Some value -> FSharpValue.MakeUnion(case, [| value |]) |> Some
+      | fields ->
+        failwith
+          $"Expected union {case.DeclaringType.Name} to have exactly one field in each case, but case {case.Name} has {fields.Length} fields"
+
+
+    let cases = FSharpType.GetUnionCases(t)
+    let json = JToken.ReadFrom reader
+    let c = cases |> Array.tryPick (tryMakeUnionCase json)
+
+    match c with
+    | None -> failwith $"Could not create an instance of the type '%s{t.Name}'"
+    | Some c -> c
+
+/// converter that can convert enum-style DUs
+type SingleCaseUnionConverter() =
+  inherit JsonConverter()
+
+
+  let canConvert =
+    let allCases (t: System.Type) = FSharpType.GetUnionCases t
+
+    memorise (fun t ->
+      FSharpType.IsUnion t
+      && allCases t
+         |> Array.forall (fun c -> c.GetFields().Length = 0))
+
+  override _.CanConvert t = canConvert t
+
+  override _.WriteJson(writer: Newtonsoft.Json.JsonWriter, value: obj, serializer: Newtonsoft.Json.JsonSerializer) =
+    serializer.Serialize(writer, string value)
+
+  override _.ReadJson(reader: Newtonsoft.Json.JsonReader, t, _existingValue, serializer) =
+    let caseName = string reader.Value
+
+    match
+      FSharpType.GetUnionCases(t)
+      |> Array.tryFind (fun c -> c.Name.Equals(caseName, StringComparison.OrdinalIgnoreCase))
+      with
+    | Some caseInfo -> FSharpValue.MakeUnion(caseInfo, [||])
+    | None -> failwith $"Could not create an instance of the type '%s{t.Name}' with the name '%s{caseName}'"
+
+type U2BoolObjectConverter() =
+  inherit JsonConverter()
+
+  let canConvert =
+    memorise (fun (t: System.Type) ->
+      t.IsGenericType
+      && t.GetGenericTypeDefinition() = typedefof<U2<_, _>>
+      && t.GetGenericArguments().Length = 2
+      && t.GetGenericArguments().[0] = typeof<bool>
+      && not (t.GetGenericArguments().[1].IsValueType))
+
+  override _.CanConvert t = canConvert t
+
+  override _.WriteJson(writer, value, serializer) =
+    let case, fields = FSharpValue.GetUnionFields(value, value.GetType())
+
+    match case.Name with
+    | "First" -> writer.WriteValue(value :?> bool)
+    | "Second" -> serializer.Serialize(writer, fields.[0])
+    | _ -> failwith $"Unrecognized case '{case.Name}' for union type '{value.GetType().FullName}'."
+
+  override _.ReadJson(reader, t, _existingValue, serializer) =
+    let cases = FSharpType.GetUnionCases(t)
+
+    match reader.TokenType with
+    | JsonToken.Boolean ->
+      // 'First' side
+      FSharpValue.MakeUnion(cases.[0], [| box (reader.Value :?> bool) |])
+    | JsonToken.StartObject ->
+      // Second side
+      let value = serializer.Deserialize(reader, (t.GetGenericArguments().[1]))
+      FSharpValue.MakeUnion(cases.[1], [| value |])
+    | _ ->
+      failwithf $"Unrecognized json TokenType '%s{string reader.TokenType}' when reading value of type '{t.FullName}'"
+
+type OptionConverter() =
+  inherit JsonConverter()
+
+  override __.CanConvert(t) =
+    t.IsGenericType
+    && t.GetGenericTypeDefinition() = typedefof<option<_>>
+
+  override __.WriteJson(writer, value, serializer) =
+    let value =
+      if isNull value then
+        null
+      else
+        let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
+        fields.[0]
+
+    serializer.Serialize(writer, value)
+
+  override __.ReadJson(reader, t, _existingValue, serializer) =
+    let innerType = t.GetGenericArguments().[0]
+
+    let innerType =
+      if innerType.IsValueType then
+        (typedefof<Nullable<_>>).MakeGenericType([| innerType |])
+      else
+        innerType
+
+    let value = serializer.Deserialize(reader, innerType)
+    let cases = FSharpType.GetUnionCases(t)
+
+    if isNull value then
+      FSharpValue.MakeUnion(cases.[0], [||])
+    else
+      FSharpValue.MakeUnion(cases.[1], [| value |])

--- a/src/JsonUtils.fs
+++ b/src/JsonUtils.fs
@@ -25,6 +25,7 @@ open System.Reflection
 /// {}                                // error
 /// { "name": "foo", "data": "bar" }  // ok
 /// ```
+[<Sealed>]
 type OptionAndCamelCasePropertyNamesContractResolver() =
   inherit CamelCasePropertyNamesContractResolver()
 
@@ -89,6 +90,7 @@ module private UnionInfo =
 /// Newtonsoft.Json parses parses a number inside quotations as number too:
 /// `"42"` -> can be parsed to `42: int`
 /// This converter prevents that. `"42"` cannot be parsed to `int` (or `float`) any more
+[<Sealed>]
 type StrictNumberConverter() =
   inherit JsonConverter()
 
@@ -120,6 +122,7 @@ type StrictNumberConverter() =
 
 /// Like `StrictNumberConverter`, but prevents numbers to be parsed as string:
 /// `42` -> no quotation marks -> not a string
+[<Sealed>]
 type StrictStringConverter() =
   inherit JsonConverter()
 
@@ -138,6 +141,7 @@ type StrictStringConverter() =
 
 /// Like `StrictNumberConverter`, but prevents boolean to be parsed as string:
 /// `true` -> no quotation marks -> not a string
+[<Sealed>]
 type StrictBoolConverter() =
   inherit JsonConverter()
 
@@ -154,6 +158,7 @@ type StrictBoolConverter() =
   override _.CanWrite = false
   override _.WriteJson(_,_,_) = raise (NotImplementedException())
 
+[<Sealed>]
 type ErasedUnionConverter() =
   inherit JsonConverter()
 
@@ -227,6 +232,7 @@ type ErasedUnionConverter() =
     | Some c -> c
 
 /// converter that can convert enum-style DUs
+[<Sealed>]
 type SingleCaseUnionConverter() =
   inherit JsonConverter()
 
@@ -256,6 +262,7 @@ type SingleCaseUnionConverter() =
     | Some case -> case.Create [||]
     | None -> failwith $"Could not create an instance of the type '%s{t.Name}' with the name '%s{caseName}'"
 
+[<Sealed>]
 type OptionConverter() =
   inherit JsonConverter()
 

--- a/src/JsonUtils.fs
+++ b/src/JsonUtils.fs
@@ -38,7 +38,7 @@ type OptionAndCamelCasePropertyNamesContractResolver() =
 
     for prop in props do
       if isOptionType prop.PropertyType then
-        prop.Required <- Required.DisallowNull
+        prop.Required <- Required.Default
       else
         prop.Required <- Required.Always
 

--- a/src/JsonUtils.fs
+++ b/src/JsonUtils.fs
@@ -181,11 +181,29 @@ type ErasedUnionConverter() =
 
   override __.ReadJson(reader: JsonReader, t, _existingValue, serializer) =
     let tryReadValue (json: JToken) (targetType: Type) =
-        //TODO: custom handling simple types to prevent exceptions?
-        try
-          json.ToObject(targetType, serializer) |> Some
-        with
-        | _ -> None
+        if targetType = typeof<string> then
+          if json.Type = JTokenType.String then
+            reader.Value
+            |> Some
+          else
+            None
+        elif targetType = typeof<bool> then
+          if json.Type = JTokenType.Boolean then
+            reader.Value
+            |> Some
+          else
+            None
+        elif targetType = typeof<int> || targetType = typeof<float> || targetType = typeof<byte> then
+          match json.Type with
+          | JTokenType.Integer | JTokenType.Float ->
+              json.ToObject(targetType, serializer)
+              |> Some
+          | _ -> None
+        else
+            try
+              json.ToObject(targetType, serializer) |> Some
+            with
+            | _ -> None
 
     let union = getUnionInfo t
     let json = JToken.ReadFrom reader

--- a/src/JsonUtils.fs
+++ b/src/JsonUtils.fs
@@ -207,7 +207,7 @@ type U2BoolObjectConverter() =
         union.Cases[0].Create [| box (reader.Value :?> bool) |]
     | JsonToken.StartObject ->
       // Second side
-      let value = serializer.Deserialize(reader, (t.GetGenericArguments().[1])) //TODO: cache GenericArguments?
+      let value = serializer.Deserialize(reader, (t.GetGenericArguments()[1]))
       union.Cases[1].Create [| value |]
     | _ ->
       failwithf $"Unrecognized json TokenType '%s{string reader.TokenType}' when reading value of type '{t.FullName}'"
@@ -238,7 +238,7 @@ type OptionConverter() =
     match reader.TokenType with
     | JsonToken.Null -> null  // = None
     | _ ->
-      let innerType = t.GetGenericArguments().[0] //TODO: cache generic args
+      let innerType = t.GetGenericArguments()[0]
       let innerType =
         if innerType.IsValueType then
           (typedefof<Nullable<_>>).MakeGenericType([| innerType |])

--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -1,133 +1,5 @@
 namespace Ionide.LanguageServerProtocol
 
-module LspJsonConverters =
-  open Microsoft.FSharp.Reflection
-  open Newtonsoft.Json
-  open System
-  open System.Collections.Concurrent
-  open Ionide.LanguageServerProtocol.Types
-
-  let inline memorise (f: 'a -> 'b) : ('a -> 'b) =
-    let d = ConcurrentDictionary<'a, 'b>()
-    fun key -> d.GetOrAdd(key, f)
-
-  type ErasedUnionConverter() =
-    inherit JsonConverter()
-
-    let canConvert =
-      memorise (fun t ->
-        if not (FSharpType.IsUnion t) then
-          false
-        else
-          t.BaseType.GetCustomAttributes(typedefof<ErasedUnionAttribute>, false).Length > 0)
-
-    override __.CanConvert(t) = canConvert t
-
-    override __.WriteJson(writer, value, serializer) =
-      let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
-      let unionField = fields.[0]
-      serializer.Serialize(writer, unionField)
-
-    override __.ReadJson(_reader, _t, _existingValue, _serializer) = failwith "Not implemented"
-
-  /// converter that can convert enum-style DUs
-  type SingleCaseUnionConverter() =
-    inherit JsonConverter()
-
-
-    let canConvert =
-      let allCases (t: System.Type) = FSharpType.GetUnionCases t
-
-      memorise (fun t ->
-        FSharpType.IsUnion t
-        && allCases t
-           |> Array.forall (fun c -> c.GetFields().Length = 0))
-
-    override _.CanConvert t = canConvert t
-
-    override _.WriteJson(writer: Newtonsoft.Json.JsonWriter, value: obj, serializer: Newtonsoft.Json.JsonSerializer) =
-      serializer.Serialize(writer, string value)
-
-    override _.ReadJson(reader: Newtonsoft.Json.JsonReader, t, _existingValue, serializer) =
-      let caseName = string reader.Value
-
-      match
-        FSharpType.GetUnionCases(t)
-        |> Array.tryFind (fun c -> c.Name.Equals(caseName, StringComparison.OrdinalIgnoreCase))
-        with
-      | Some caseInfo -> FSharpValue.MakeUnion(caseInfo, [||])
-      | None -> failwith $"Could not create an instance of the type '%s{t.Name}' with the name '%s{caseName}'"
-
-  type U2BoolObjectConverter() =
-    inherit JsonConverter()
-
-    let canConvert =
-      memorise (fun (t: System.Type) ->
-        t.IsGenericType
-        && t.GetGenericTypeDefinition() = typedefof<U2<_, _>>
-        && t.GetGenericArguments().Length = 2
-        && t.GetGenericArguments().[0] = typeof<bool>
-        && not (t.GetGenericArguments().[1].IsValueType))
-
-    override _.CanConvert t = canConvert t
-
-    override _.WriteJson(writer, value, serializer) =
-      let case, fields = FSharpValue.GetUnionFields(value, value.GetType())
-
-      match case.Name with
-      | "First" -> writer.WriteValue(value :?> bool)
-      | "Second" -> serializer.Serialize(writer, fields.[0])
-      | _ -> failwith $"Unrecognized case '{case.Name}' for union type '{value.GetType().FullName}'."
-
-    override _.ReadJson(reader, t, _existingValue, serializer) =
-      let cases = FSharpType.GetUnionCases(t)
-
-      match reader.TokenType with
-      | JsonToken.Boolean ->
-        // 'First' side
-        FSharpValue.MakeUnion(cases.[0], [| box (reader.Value :?> bool) |])
-      | JsonToken.StartObject ->
-        // Second side
-        let value = serializer.Deserialize(reader, (t.GetGenericArguments().[1]))
-        FSharpValue.MakeUnion(cases.[1], [| value |])
-      | _ ->
-        failwithf $"Unrecognized json TokenType '%s{string reader.TokenType}' when reading value of type '{t.FullName}'"
-
-  type OptionConverter() =
-    inherit JsonConverter()
-
-    override __.CanConvert(t) =
-      t.IsGenericType
-      && t.GetGenericTypeDefinition() = typedefof<option<_>>
-
-    override __.WriteJson(writer, value, serializer) =
-      let value =
-        if isNull value then
-          null
-        else
-          let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
-          fields.[0]
-
-      serializer.Serialize(writer, value)
-
-    override __.ReadJson(reader, t, _existingValue, serializer) =
-      let innerType = t.GetGenericArguments().[0]
-
-      let innerType =
-        if innerType.IsValueType then
-          (typedefof<Nullable<_>>).MakeGenericType([| innerType |])
-        else
-          innerType
-
-      let value = serializer.Deserialize(reader, innerType)
-      let cases = FSharpType.GetUnionCases(t)
-
-      if isNull value then
-        FSharpValue.MakeUnion(cases.[0], [||])
-      else
-        FSharpValue.MakeUnion(cases.[1], [| value |])
-
-
 module Server =
   open System
   open System.IO
@@ -139,7 +11,7 @@ module Server =
   open StreamJsonRpc
   open Newtonsoft.Json
   open Newtonsoft.Json.Serialization
-  open LspJsonConverters
+  open Ionide.LanguageServerProtocol.JsonConverters
   open Newtonsoft.Json.Linq
 
   let logger = LogProvider.getLoggerByName "LSP Server"
@@ -385,7 +257,7 @@ module Client =
   open Ionide.LanguageServerProtocol
   open Ionide.LanguageServerProtocol.JsonRpc
   open Ionide.LanguageServerProtocol.Logging
-  open LspJsonConverters
+  open Ionide.LanguageServerProtocol.JsonConverters
   open Newtonsoft.Json
   open Newtonsoft.Json.Serialization
   open Newtonsoft.Json.Linq

--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -10,8 +10,7 @@ module Server =
   open System.Reflection
   open StreamJsonRpc
   open Newtonsoft.Json
-  open Newtonsoft.Json.Serialization
-  open Ionide.LanguageServerProtocol.JsonConverters
+  open Ionide.LanguageServerProtocol.JsonUtils
   open Newtonsoft.Json.Linq
 
   let logger = LogProvider.getLoggerByName "LSP Server"
@@ -24,7 +23,7 @@ module Server =
   jsonRpcFormatter.JsonSerializer.Converters.Add(U2BoolObjectConverter())
   jsonRpcFormatter.JsonSerializer.Converters.Add(OptionConverter())
   jsonRpcFormatter.JsonSerializer.Converters.Add(ErasedUnionConverter())
-  jsonRpcFormatter.JsonSerializer.ContractResolver <- CamelCasePropertyNamesContractResolver()
+  jsonRpcFormatter.JsonSerializer.ContractResolver <- OptionAndCamelCasePropertyNamesContractResolver()
 
   let deserialize<'t> (token: JToken) = token.ToObject<'t>(jsonRpcFormatter.JsonSerializer)
   let serialize<'t> (o: 't) = JToken.FromObject(o, jsonRpcFormatter.JsonSerializer)
@@ -257,7 +256,7 @@ module Client =
   open Ionide.LanguageServerProtocol
   open Ionide.LanguageServerProtocol.JsonRpc
   open Ionide.LanguageServerProtocol.Logging
-  open Ionide.LanguageServerProtocol.JsonConverters
+  open Ionide.LanguageServerProtocol.JsonUtils
   open Newtonsoft.Json
   open Newtonsoft.Json.Serialization
   open Newtonsoft.Json.Linq

--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -19,8 +19,10 @@ module Server =
   jsonRpcFormatter.JsonSerializer.NullValueHandling <- NullValueHandling.Ignore
   jsonRpcFormatter.JsonSerializer.ConstructorHandling <- ConstructorHandling.AllowNonPublicDefaultConstructor
   jsonRpcFormatter.JsonSerializer.MissingMemberHandling <- MissingMemberHandling.Ignore
+  jsonRpcFormatter.JsonSerializer.Converters.Add(StrictNumberConverter())
+  jsonRpcFormatter.JsonSerializer.Converters.Add(StrictStringConverter())
+  jsonRpcFormatter.JsonSerializer.Converters.Add(StrictBoolConverter())
   jsonRpcFormatter.JsonSerializer.Converters.Add(SingleCaseUnionConverter())
-  jsonRpcFormatter.JsonSerializer.Converters.Add(U2BoolObjectConverter())
   jsonRpcFormatter.JsonSerializer.Converters.Add(OptionConverter())
   jsonRpcFormatter.JsonSerializer.Converters.Add(ErasedUnionConverter())
   jsonRpcFormatter.JsonSerializer.ContractResolver <- OptionAndCamelCasePropertyNamesContractResolver()

--- a/tests/Benchmarks.fs
+++ b/tests/Benchmarks.fs
@@ -153,11 +153,10 @@ type MultipleTypesBenchmarks() =
       ()
   [<Benchmark>]
   member b.All_MultipleRoundtrips() =
-    for i in 0..250 do
+    for _ in 0..250 do
       b.All_Roundtrip()
 
-
-let run (args) =
+let run (args: string[]) =
   let switcher = BenchmarkSwitcher.FromTypes([| typeof<MultipleTypesBenchmarks> |])
   switcher.Run(args) |> ignore
   0

--- a/tests/Benchmarks.fs
+++ b/tests/Benchmarks.fs
@@ -6,49 +6,108 @@ open Newtonsoft.Json.Linq
 open BenchmarkDotNet.Attributes
 open BenchmarkDotNet.Running
 
-type Record1 = { Name: string; Value: int }
-
 [<MemoryDiagnoser>]
-type U2Benchmarks() =
-  let simpleU2First: U2<int, string> = U2.First 42
-  let simpleU2FirstJson = serialize simpleU2First
-  let simpleU2Second: U2<int, string> = U2.Second "foo"
-  let simpleU2SecondJson = serialize simpleU2Second
-  let complexU2: U2<string, Record1> = U2.Second { Name = "foo"; Value = 42 }
-  let complexU2Json = serialize complexU2
+type MultipleTypesBenchmarks() =
+  let initializeParams: InitializeParams =
+    { ProcessId = Some 42
+      ClientInfo = Some { Name = "foo"; Version = None }
+      RootPath = Some "/"
+      RootUri = Some "file://..."
+      InitializationOptions = None
+      Capabilities =
+        Some
+          { Workspace =
+              Some
+                { ApplyEdit = Some true
+                  WorkspaceEdit =
+                    Some
+                      { DocumentChanges = Some true
+                        ResourceOperations =
+                          Some [| ResourceOperationKind.Create
+                                  ResourceOperationKind.Rename
+                                  ResourceOperationKind.Delete |]
+                        FailureHandling = Some FailureHandlingKind.Abort
+                        NormalizesLineEndings = None
+                        ChangeAnnotationSupport = Some { GroupsOnLabel = Some false } }
+                  DidChangeConfiguration = None
+                  DidChangeWatchedFiles = None
+                  Symbol =
+                    Some
+                      { DynamicRegistration = Some false
+                        SymbolKind = Some { ValueSet = Some SymbolKindCapabilities.DefaultValueSet } }
+                  SemanticTokens = Some { RefreshSupport = Some true }
+                  InlayHint = Some { RefreshSupport = Some false } }
+            TextDocument =
+              Some
+                { Synchronization =
+                    Some
+                      { DynamicRegistration = Some true
+                        WillSave = Some true
+                        WillSaveWaitUntil = Some false
+                        DidSave = Some true }
+                  PublishDiagnostics = { RelatedInformation = None; TagSupport = None }
+                  Completion = None
+                  Hover =
+                    Some
+                      { DynamicRegistration = Some true
+                        ContentFormat = Some [| "markup"; "plaintext" |] }
+                  SignatureHelp =
+                    Some
+                      { DynamicRegistration = Some true
+                        SignatureInformation = Some { DocumentationFormat = None } }
+                  References = Some { DynamicRegistration = Some false }
+                  DocumentHighlight = Some { DynamicRegistration = None }
+                  DocumentSymbol = None
+                  Formatting = Some { DynamicRegistration = Some true }
+                  RangeFormatting = Some { DynamicRegistration = Some true }
+                  OnTypeFormatting = None
+                  Definition = Some { DynamicRegistration = Some false }
+                  CodeAction =
+                    Some
+                      { DynamicRegistration = Some true
+                        CodeActionLiteralSupport =
+                          Some
+                            { CodeActionKind =
+                                { ValueSet = [| "foo"; "bar"; "baz"; "alpha"; "beta"; "gamma"; "delta"; "x"; "y"; "z" |] } }
+                        IsPreferredSupport = Some true
+                        DisabledSupport = Some false
+                        DataSupport = None
+                        ResolveSupport = Some { Properties = [| "foo"; "bar"; "baz" |] }
+                        HonorsChangeAnnotations = Some false }
+                  CodeLens = Some { DynamicRegistration = Some true }
+                  DocumentLink = Some { DynamicRegistration = Some true }
+                  Rename = None
+                  FoldingRange =
+                    Some
+                      { DynamicRegistration = Some false
+                        LineFoldingOnly = Some true
+                        RangeLimit = None }
+                  SelectionRange = Some { DynamicRegistration = None }
+                  SemanticTokens =
+                    Some
+                      { DynamicRegistration = Some false
+                        Requests = { Range = Some(U2.First true); Full = Some(U2.Second { Delta = Some true }) }
+                        TokenTypes =
+                          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Proin tortor purus platea sit eu id nisi litora libero. Neque vulputate consequat ac amet augue blandit maximus aliquet congue. Pharetra vestibulum posuere ornare faucibus fusce dictumst orci aenean eu facilisis ut volutpat commodo senectus purus himenaeos fames primis convallis nisi."
+                          |> fun s -> s.Split(' ')
+                        TokenModifiers =
+                          "Phasellus fermentum malesuada phasellus netus dictum aenean placerat egestas amet. Ornare taciti semper dolor tristique morbi. Sem leo tincidunt aliquet semper eu lectus scelerisque quis. Sagittis vivamus mollis nisi mollis enim fermentum laoreet."
+                          |> fun s -> s.Split(' ')
+                        Formats = [| TokenFormat.Relative |]
+                        OverlappingTokenSupport = Some false
+                        MultilineTokenSupport = Some true }
+                  InlayHint =
+                    Some
+                      { DynamicRegistration = Some true
+                        ResolveSupport = Some { Properties = [| "Tooltip"; "Position"; "TextEdits" |] } } }
+            Experimental = None }
+      trace = None
+      WorkspaceFolders =
+        Some [| { Uri = "..."; Name = "foo" }
+                { Uri = "/"; Name = "bar" }
+                { Uri = "something long stuff and even longer and longer and longer"
+                  Name = "bar" } |] }
 
-  [<Benchmark>]
-  member _.SimpleU2First_Serialize() = simpleU2First |> serialize
-
-  [<Benchmark>]
-  member _.SimpleU2First_Deserialize() = simpleU2FirstJson |> deserialize<U2<int, string>>
-
-  [<Benchmark>]
-  member _.SimpleU2First_Roundtrip() = simpleU2First |> serialize |> deserialize<U2<int, string>>
-
-  [<Benchmark>]
-  member _.SimpleU2Second_Serialize() = simpleU2Second |> serialize
-
-  [<Benchmark>]
-  member _.SimpleU2Second_Deserialize() = simpleU2SecondJson |> deserialize<U2<int, string>>
-
-  [<Benchmark>]
-  member _.SimpleU2Second_Roundtrip() = simpleU2First |> serialize |> deserialize<U2<int, string>>
-
-  [<Benchmark>]
-  member _.complexU2_Serialize() = complexU2 |> serialize
-
-  [<Benchmark>]
-  member _.complexU2_Deserialize() = complexU2Json |> deserialize<U2<string, Record1>>
-
-  [<Benchmark>]
-  member _.complexU2_Roundtrip() =
-    simpleU2First
-    |> serialize
-    |> deserialize<U2<string, Record1>>
-
-[<MemoryDiagnoser>]
-type InlayHintBenchmarks() =
   let inlayHint: InlayHint =
     { Label =
         InlayHintLabel.Parts [| { InlayHintLabelPart.Value = "1st label"
@@ -84,21 +143,17 @@ type InlayHintBenchmarks() =
       PaddingRight = Some false
       Data = Some(JToken.FromObject "some data") }
 
-  let jtoken = serialize inlayHint
-  let json = jtoken.ToString()
-
+  let all: obj [] = [| initializeParams; inlayHint |]
 
   [<Benchmark>]
-  member _.ComplexInlayHint_Serialize() = inlayHint |> serialize
-
-  [<Benchmark>]
-  member _.ComplexInlayHint_Deserialize() = jtoken |> deserialize<InlayHint>
-
-  [<Benchmark>]
-  member _.ComplexInlayHint_Roundtrip() = inlayHint |> serialize |> deserialize<InlayHint>
+  member _.All_Roundtrip() =
+    for o in all do
+      let json = inlayHint |> serialize
+      let res = json.ToObject(o.GetType(), jsonRpcFormatter.JsonSerializer)
+      ()
 
 
 let run (args) =
-  let switcher = BenchmarkSwitcher.FromTypes([| typeof<U2Benchmarks>; typeof<InlayHintBenchmarks> |])
+  let switcher = BenchmarkSwitcher.FromTypes([| typeof<MultipleTypesBenchmarks> |])
   switcher.Run(args) |> ignore
   0

--- a/tests/Benchmarks.fs
+++ b/tests/Benchmarks.fs
@@ -151,6 +151,10 @@ type MultipleTypesBenchmarks() =
       let json = inlayHint |> serialize
       let res = json.ToObject(o.GetType(), jsonRpcFormatter.JsonSerializer)
       ()
+  [<Benchmark>]
+  member b.All_MultipleRoundtrips() =
+    for i in 0..250 do
+      b.All_Roundtrip()
 
 
 let run (args) =

--- a/tests/Benchmarks.fs
+++ b/tests/Benchmarks.fs
@@ -151,12 +151,13 @@ type MultipleTypesBenchmarks() =
       let json = inlayHint |> serialize
       let res = json.ToObject(o.GetType(), jsonRpcFormatter.JsonSerializer)
       ()
+
   [<Benchmark>]
   member b.All_MultipleRoundtrips() =
     for _ in 0..250 do
       b.All_Roundtrip()
 
-let run (args: string[]) =
+let run (args: string []) =
   let switcher = BenchmarkSwitcher.FromTypes([| typeof<MultipleTypesBenchmarks> |])
   switcher.Run(args) |> ignore
   0

--- a/tests/Benchmarks.fs
+++ b/tests/Benchmarks.fs
@@ -1,0 +1,104 @@
+module Ionide.LanguageServerProtocol.Tests.Benchmarks
+
+open Ionide.LanguageServerProtocol.Types
+open Ionide.LanguageServerProtocol.Server
+open Newtonsoft.Json.Linq
+open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Running
+
+type Record1 = { Name: string; Value: int }
+
+[<MemoryDiagnoser>]
+type U2Benchmarks() =
+  let simpleU2First: U2<int, string> = U2.First 42
+  let simpleU2FirstJson = serialize simpleU2First
+  let simpleU2Second: U2<int, string> = U2.Second "foo"
+  let simpleU2SecondJson = serialize simpleU2Second
+  let complexU2: U2<string, Record1> = U2.Second { Name = "foo"; Value = 42 }
+  let complexU2Json = serialize complexU2
+
+  [<Benchmark>]
+  member _.SimpleU2First_Serialize() = simpleU2First |> serialize
+
+  [<Benchmark>]
+  member _.SimpleU2First_Deserialize() = simpleU2FirstJson |> deserialize<U2<int, string>>
+
+  [<Benchmark>]
+  member _.SimpleU2First_Roundtrip() = simpleU2First |> serialize |> deserialize<U2<int, string>>
+
+  [<Benchmark>]
+  member _.SimpleU2Second_Serialize() = simpleU2Second |> serialize
+
+  [<Benchmark>]
+  member _.SimpleU2Second_Deserialize() = simpleU2SecondJson |> deserialize<U2<int, string>>
+
+  [<Benchmark>]
+  member _.SimpleU2Second_Roundtrip() = simpleU2First |> serialize |> deserialize<U2<int, string>>
+
+  [<Benchmark>]
+  member _.complexU2_Serialize() = complexU2 |> serialize
+
+  [<Benchmark>]
+  member _.complexU2_Deserialize() = complexU2Json |> deserialize<U2<string, Record1>>
+
+  [<Benchmark>]
+  member _.complexU2_Roundtrip() =
+    simpleU2First
+    |> serialize
+    |> deserialize<U2<string, Record1>>
+
+[<MemoryDiagnoser>]
+type InlayHintBenchmarks() =
+  let inlayHint: InlayHint =
+    { Label =
+        InlayHintLabel.Parts [| { InlayHintLabelPart.Value = "1st label"
+                                  Tooltip = Some(InlayHintTooltip.String "1st label tooltip")
+                                  Location = Some { Uri = "1st"; Range = mkRange' (1, 2) (3, 4) }
+                                  Command = None }
+                                { Value = "2nd label"
+                                  Tooltip = Some(InlayHintTooltip.String "1st label tooltip")
+                                  Location = Some { Uri = "2nd"; Range = mkRange' (5, 8) (10, 9) }
+                                  Command = Some { Title = "2nd command"; Command = "foo"; Arguments = None } }
+                                { InlayHintLabelPart.Value = "3rd label"
+                                  Tooltip =
+                                    Some(
+                                      InlayHintTooltip.Markup
+                                        { Kind = MarkupKind.Markdown
+                                          Value =
+                                            """
+                                            # Header
+                                            Description
+                                            * List 1
+                                            * List 2
+                                            """ }
+                                    )
+                                  Location = Some { Uri = "3rd"; Range = mkRange' (1, 2) (3, 4) }
+                                  Command = None } |]
+      Position = { Line = 5; Character = 10 }
+      Kind = Some InlayHintKind.Type
+      TextEdits =
+        Some [| { Range = mkRange' (5, 10) (6, 5); NewText = "foo bar" }
+                { Range = mkRange' (5, 0) (5, 2); NewText = "baz" } |]
+      Tooltip = Some(InlayHintTooltip.Markup { Kind = MarkupKind.PlainText; Value = "some tooltip" })
+      PaddingLeft = Some true
+      PaddingRight = Some false
+      Data = Some(JToken.FromObject "some data") }
+
+  let jtoken = serialize inlayHint
+  let json = jtoken.ToString()
+
+
+  [<Benchmark>]
+  member _.ComplexInlayHint_Serialize() = inlayHint |> serialize
+
+  [<Benchmark>]
+  member _.ComplexInlayHint_Deserialize() = jtoken |> deserialize<InlayHint>
+
+  [<Benchmark>]
+  member _.ComplexInlayHint_Roundtrip() = inlayHint |> serialize |> deserialize<InlayHint>
+
+
+let run (args) =
+  let switcher = BenchmarkSwitcher.FromTypes([| typeof<U2Benchmarks>; typeof<InlayHintBenchmarks> |])
+  switcher.Run(args) |> ignore
+  0

--- a/tests/Ionide.LanguageServerProtocol.Tests.fsproj
+++ b/tests/Ionide.LanguageServerProtocol.Tests.fsproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Utils.fs" />
+    <Compile Include="Benchmarks.fs" />
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Expecto" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Ionide.LanguageServerProtocol.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Program.fs
+++ b/tests/Program.fs
@@ -1,5 +1,7 @@
 ﻿module Ionide.LanguageServerProtocol.Tests.Root
 
+open Expecto.Tests
+
 [<EntryPoint>]
 let main args =
   let (|ShouldRunBenchmarks|_|) (args: string []) =
@@ -16,4 +18,4 @@ let main args =
   | ShouldRunBenchmarks args ->
     // `--filter *` to run all
     Benchmarks.run args
-  | _ -> Expecto.Tests.runTestsWithCLIArgs [] args Tests.tests
+  | _ -> Expecto.Tests.runTestsWithCLIArgs [ Sequenced ] args Tests.tests

--- a/tests/Program.fs
+++ b/tests/Program.fs
@@ -1,0 +1,19 @@
+﻿module Ionide.LanguageServerProtocol.Tests.Root
+
+[<EntryPoint>]
+let main args =
+  let (|ShouldRunBenchmarks|_|) (args: string []) =
+    let nArgs = args.Length
+    let markers = [| "--benchmark"; "--benchmarks"; "-b" |]
+
+    let args =
+      args
+      |> Array.filter (fun arg -> markers |> Array.contains arg |> not)
+
+    if args.Length = nArgs then None else Some args
+
+  match args with
+  | ShouldRunBenchmarks args ->
+    // `--filter *` to run all
+    Benchmarks.run args
+  | _ -> Expecto.Tests.runTestsWithCLIArgs [] args Tests.tests

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -305,6 +305,18 @@ let private serializationTests =
                let input = NoFields.Second
                testThereAndBackAgain input ]
 
+      testList "JsonProperty" [
+        testCase "keep null when serializing VersionedTextDocumentIdentifier" <| fun _ ->
+          let textDoc = { VersionedTextDocumentIdentifier.Uri = "..."; Version = None }
+          let json = textDoc |> serialize :?> JObject
+          let prop = json.Property("version")
+          let value = prop.Value
+          Expect.equal (value.Type) (JTokenType.Null) "Version should be null"
+        testCase "can deserialize null Version in VersionedTextDocumentIdentifier" <| fun _ ->
+          let textDoc = { VersionedTextDocumentIdentifier.Uri = "..."; Version = None }
+          testThereAndBackAgain textDoc
+      ]
+
       testList
         (nameof InlayHint)
         [

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -55,8 +55,6 @@ type AllRequired = { RequiredName: string; RequiredValue: int }
 type OneOptional = { RequiredName: string; OptionalValue: int option }
 type AllOptional = { OptionalName: string option; OptionalValue: int option }
 
-
-
 let private serializationTests =
   testList
     "(de)serialization"
@@ -280,7 +278,54 @@ let private serializationTests =
                      (fun _ -> json |> deserialize<OneOptional> |> ignore)
                      "Should fail without required member"
 
-              ] ]
+              ] 
+
+          testList "string vs int" [
+            testCase "can deserialize int to U2<int,string>" <| fun _ ->
+              let input: U2<int, string> = U2.First 42
+              testThereAndBackAgain input
+            testCase "can deserialize string to U2<int,string>" <| fun _ ->
+              let input: U2<int, string> = U2.Second "foo"
+              testThereAndBackAgain input
+            testCase "can deserialize 42 string to U2<int,string>" <| fun _ ->
+              let input: U2<int, string> = U2.Second "42"
+              testThereAndBackAgain input
+
+            testCase "can deserialize int to U2<string, int>" <| fun _ ->
+              let input: U2<string, int> = U2.Second 42
+              testThereAndBackAgain input
+            testCase "can deserialize string to U2<string, string>" <| fun _ ->
+              let input: U2<string, int> = U2.First "foo"
+              testThereAndBackAgain input
+            testCase "can deserialize 42 string to U2<string,int>" <| fun _ ->
+              let input: U2<string, int> = U2.First "42"
+              testThereAndBackAgain input
+          ]
+          testList "string vs bool" [
+            testCase "can deserialize bool to U2<bool,string>" <| fun _ ->
+              let input: U2<bool, string> = U2.First true
+              testThereAndBackAgain input
+            testCase "can deserialize string to U2<bool,string>" <| fun _ ->
+              let input: U2<bool, string> = U2.Second "foo"
+              testThereAndBackAgain input
+            testCase "can deserialize true string to U2<bool,string>" <| fun _ ->
+              let input: U2<bool, string> = U2.Second "true"
+              testThereAndBackAgain input
+
+            testCase "can deserialize bool true to U2<string, bool>" <| fun _ ->
+              let input: U2<string, bool> = U2.Second true
+              testThereAndBackAgain input
+            testCase "can deserialize bool false to U2<string, bool>" <| fun _ ->
+              let input: U2<string, bool> = U2.Second false
+              testThereAndBackAgain input
+            testCase "can deserialize string to U2<string, string>" <| fun _ ->
+              let input: U2<string, bool> = U2.First "foo"
+              testThereAndBackAgain input
+            testCase "can deserialize true string to U2<string,bool>" <| fun _ ->
+              let input: U2<string, bool> = U2.First "true"
+              testThereAndBackAgain input
+          ]
+        ]
 
       testList
         "ErasedUnionConverter"

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -55,6 +55,7 @@ type AllRequired = { RequiredName: string; RequiredValue: int }
 type OneOptional = { RequiredName: string; OptionalValue: int option }
 type AllOptional = { OptionalName: string option; OptionalValue: int option }
 
+type OneOptionalStruct = { RequiredName: string; OptionalValue: int voption }
 
 
 let private serializationTests =
@@ -202,7 +203,26 @@ let private serializationTests =
                      |> addProperty "foo" "bar"
                      |> addProperty "baz" 42
 
-                   json |> deserialize<AllOptional> |> ignore ] ]
+                   json |> deserialize<AllOptional> |> ignore ]
+
+          testList
+            "voption"
+            [ testCase "can (de)serialize with ValueSome"
+              <| fun _ ->
+                   let input = { OneOptionalStruct.RequiredName = "foo"; OptionalValue = ValueSome 42 }
+                   testThereAndBackAgain input
+              testCase "can (de)serialize with ValueNone"
+              <| fun _ ->
+                   let input = { OneOptionalStruct.RequiredName = "foo"; OptionalValue = ValueNone }
+                   testThereAndBackAgain input
+              testCase "doesn't emit property for ValueNone"
+              <| fun _ ->
+                   let input = { OneOptionalStruct.RequiredName = "foo"; OptionalValue = ValueNone }
+                   let json = serialize input
+                   let prop = json |> tryGetProperty (nameof input.OptionalValue)
+                   Expect.isNone prop "OptionalValue with ValueNone should not get serialized"
+
+              ] ]
 
       testList
         "U2"
@@ -291,10 +311,7 @@ let private serializationTests =
                let input = EU2("foo", 42)
 
                Expect.throws
-                 (fun _ ->
-                   serialize input
-                   |> fun t -> printfn "%A" (t.ToString())
-                   |> ignore)
+                 (fun _ -> serialize input |> ignore)
                  "ErasedUnion with multiple fields should not serializable"
           testCase "can (de)serialize struct union"
           <| fun _ ->

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -1,0 +1,238 @@
+module Ionide.LanguageServerProtocol.Tests.Tests
+
+open Expecto
+open Ionide.LanguageServerProtocol.Types
+open Ionide.LanguageServerProtocol.Server
+open Ionide.LanguageServerProtocol.Tests
+open Newtonsoft.Json.Linq
+open Newtonsoft.Json
+
+type Record1 = { Name: string; Value: int }
+type Record2 = { Name: string; Position: int }
+type InlayHintData = { TextDocument: TextDocumentIdentifier; Range: Range }
+
+/// Note: By default private fields don't get serialized
+/// That can be changed by either a custom ContractResolver
+/// or annotating all private fields with `JsonPropertyAttribute`.
+///
+/// The latter is used here
+///
+///
+/// But this cannot be deserialized again because:
+/// > Unable to find a constructor to use for type [...]
+///
+/// Solvable with custom Converter, but not worth for LSP
+/// -> deserialization of private records is not supported
+/// And this record is just kept as reminder of this limitation
+///
+/// Considering Serialization is used for communicating with LSP client (public API),
+/// this is not really an issue.
+type private PrivateRecord =
+  { [<JsonProperty>]
+    Data: string
+    [<JsonProperty>]
+    Value: int }
+
+[<ErasedUnion>]
+type EU2 = EU2 of string * int
+
+[<RequireQualifiedAccess>]
+type NoFields =
+  | First
+  | Second
+  | Third
+
+[<RequireQualifiedAccess>]
+[<ErasedUnion>]
+[<Struct>]
+type StructEU =
+  | First of Number: int
+  | Second of Name: string
+
+
+let private serializationTests =
+  testList
+    "(de)serialization"
+    [ let thereAndBackAgain (input: 'a) : 'a = input |> serialize |> deserialize
+
+      let testThereAndBackAgain input =
+        let output = thereAndBackAgain input
+        Expect.equal output input "Input -> serialize -> deserialize should be Input again"
+
+      testList
+        "U2"
+        [ testCase "can (de)serialize U2<int,string>.First"
+          <| fun _ ->
+               let input: U2<int, string> = U2.First 42
+               testThereAndBackAgain input
+          testCase "can (de)serialize U2<int,string>.Second"
+          <| fun _ ->
+               let input: U2<int, string> = U2.Second "foo"
+               testThereAndBackAgain input
+          testCase "deserialize to first type match"
+          <| fun _ ->
+               // Cannot distinguish between same type -> pick first
+               let input: U2<int, int> = U2.Second 42
+               let output = thereAndBackAgain input
+               Expect.notEqual output input "First matching type gets matched"
+          testCase "deserialize Second int to first float"
+          <| fun _ ->
+               // Cannot distinguish between float and int
+               let input: U2<float, int> = U2.Second 42
+               let output = thereAndBackAgain input
+               Expect.notEqual output input "First matching type gets matched"
+
+          testCase "can (de)serialize Record1 in U2<Record1, int>"
+          <| fun _ ->
+               let input: U2<Record1, int> = U2.First { Record1.Name = "foo"; Value = 42 }
+               testThereAndBackAgain input
+
+          testCase "can (de)serialize Record1 in U2<int, Record1>"
+          <| fun _ ->
+               let input: U2<int, Record1> = U2.Second { Record1.Name = "foo"; Value = 42 }
+               testThereAndBackAgain input
+
+          testCase "can (de)serialize Record1 in U2<Record1, Record2>"
+          <| fun _ ->
+               let input: U2<Record1, Record2> = U2.First { Record1.Name = "foo"; Value = 42 }
+               testThereAndBackAgain input
+
+          testCase "deserialize to first complex match"
+          <| fun _ ->
+               // Because of `serializer.MissingMemberHandling = MissingMemberHandling.Ignore`:
+               // Cannot distinguish Record1 from Record2 (-> missing fields get filled with default)
+               // -> There can only be one complex type in `U2`, the other one must be a basic type!
+               let input: U2<Record2, Record1> = U2.Second { Record1.Name = "foo"; Value = 42 }
+               let output = thereAndBackAgain input
+               Expect.notEqual output input "First complex type gets matched" ]
+
+      testList
+        "ErasedUnionConverter"
+        [
+          // most tests in `U2`
+          testCase "cannot serialize case with more than one field"
+          <| fun _ ->
+               let input = EU2("foo", 42)
+
+               Expect.throws
+                 (fun _ ->
+                   serialize input
+                   |> fun t -> printfn "%A" (t.ToString())
+                   |> ignore)
+                 "ErasedUnion with multiple fields should not serializable"
+          testCase "can (de)serialize struct union"
+          <| fun _ ->
+               let input = StructEU.Second "foo"
+               testThereAndBackAgain input ]
+
+      testList
+        "SingleCaseUnionConverter"
+        [ testCase "can (de)serialize union with all zero field cases"
+          <| fun _ ->
+               let input = NoFields.Second
+               testThereAndBackAgain input ]
+
+      testList
+        (nameof InlayHint)
+        [
+          // Life of InlayHint:
+          // * output of `textDocument/inlayHint` (`InlayHint[]`)
+          // * input of `inlayHint/resolve`
+          // * output of `inlayHint/resolve`
+          // -> must be serializable as well as deserializable
+          testCase "can (de)serialize minimal InlayHint"
+          <| fun _ ->
+               let theInlayHint: InlayHint =
+                 { Label = InlayHintLabel.String "test"
+                   Position = { Line = 0; Character = 0 }
+                   Kind = None
+                   TextEdits = None
+                   Tooltip = None
+                   PaddingLeft = None
+                   PaddingRight = None
+                   Data = None }
+
+               testThereAndBackAgain theInlayHint
+          testCase "can roundtrip InlayHint with all fields (simple)"
+          <| fun _ ->
+               let theInlayHint: InlayHint =
+                 { Label = InlayHintLabel.String "test"
+                   Position = { Line = 5; Character = 10 }
+                   Kind = Some InlayHintKind.Parameter
+                   TextEdits =
+                     Some [| { Range = { Start = { Line = 5; Character = 10 }; End = { Line = 6; Character = 5 } }
+                               NewText = "foo bar" }
+                             { Range = { Start = { Line = 4; Character = 0 }; End = { Line = 5; Character = 2 } }
+                               NewText = "baz" } |]
+                   Tooltip = Some(InlayHintTooltip.String "tooltipping")
+                   PaddingLeft = Some true
+                   PaddingRight = Some false
+                   Data = Some(JToken.FromObject "some data") }
+
+               testThereAndBackAgain theInlayHint
+          testCase "can keep Data with JToken"
+          <| fun _ ->
+               // JToken doesn't use structural equality
+               // -> Expecto equal check fails even when same content in complex JToken
+               let data =
+                 { InlayHintData.TextDocument = { Uri = "..." }
+                   Range = { Start = { Line = 5; Character = 7 }; End = { Line = 5; Character = 10 } } }
+
+               let theInlayHint: InlayHint =
+                 { Label = InlayHintLabel.String "test"
+                   Position = { Line = 0; Character = 0 }
+                   Kind = None
+                   TextEdits = None
+                   Tooltip = None
+                   PaddingLeft = None
+                   PaddingRight = None
+                   Data = Some(JToken.FromObject data) }
+
+               let output = thereAndBackAgain theInlayHint
+
+               let outputData =
+                 output.Data
+                 |> Option.map (fun t -> t.ToObject<InlayHintData>())
+
+               Expect.equal outputData (Some data) "Data should not change"
+          testCase "can roundtrip InlayHint with all fields (complex)"
+          <| fun _ ->
+               let theInlayHint: InlayHint =
+                 { Label =
+                     InlayHintLabel.Parts [| { InlayHintLabelPart.Value = "1st label"
+                                               Tooltip = Some(InlayHintTooltip.String "1st label tooltip")
+                                               Location = Some { Uri = "1st"; Range = mkRange' (1, 2) (3, 4) }
+                                               Command = None }
+                                             { Value = "2nd label"
+                                               Tooltip = Some(InlayHintTooltip.String "1st label tooltip")
+                                               Location = Some { Uri = "2nd"; Range = mkRange' (5, 8) (10, 9) }
+                                               Command =
+                                                 Some { Title = "2nd command"; Command = "foo"; Arguments = None } }
+                                             { InlayHintLabelPart.Value = "3rd label"
+                                               Tooltip =
+                                                 Some(
+                                                   InlayHintTooltip.Markup
+                                                     { Kind = MarkupKind.Markdown
+                                                       Value =
+                                                         """
+                                                          # Header
+                                                          Description
+                                                          * List 1
+                                                          * List 2
+                                                          """ }
+                                                 )
+                                               Location = Some { Uri = "3rd"; Range = mkRange' (1, 2) (3, 4) }
+                                               Command = None } |]
+                   Position = { Line = 5; Character = 10 }
+                   Kind = Some InlayHintKind.Type
+                   TextEdits =
+                     Some [| { Range = mkRange' (5, 10) (6, 5); NewText = "foo bar" }
+                             { Range = mkRange' (5, 0) (5, 2); NewText = "baz" } |]
+                   Tooltip = Some(InlayHintTooltip.Markup { Kind = MarkupKind.PlainText; Value = "some tooltip" })
+                   PaddingLeft = Some true
+                   PaddingRight = Some false
+                   Data = Some(JToken.FromObject "some data") }
+
+               testThereAndBackAgain theInlayHint ] ]
+
+let tests = testList "LSP" [ serializationTests ]

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -55,7 +55,6 @@ type AllRequired = { RequiredName: string; RequiredValue: int }
 type OneOptional = { RequiredName: string; OptionalValue: int option }
 type AllOptional = { OptionalName: string option; OptionalValue: int option }
 
-type OneOptionalStruct = { RequiredName: string; OptionalValue: int voption }
 
 
 let private serializationTests =
@@ -203,26 +202,7 @@ let private serializationTests =
                      |> addProperty "foo" "bar"
                      |> addProperty "baz" 42
 
-                   json |> deserialize<AllOptional> |> ignore ]
-
-          testList
-            "voption"
-            [ testCase "can (de)serialize with ValueSome"
-              <| fun _ ->
-                   let input = { OneOptionalStruct.RequiredName = "foo"; OptionalValue = ValueSome 42 }
-                   testThereAndBackAgain input
-              testCase "can (de)serialize with ValueNone"
-              <| fun _ ->
-                   let input = { OneOptionalStruct.RequiredName = "foo"; OptionalValue = ValueNone }
-                   testThereAndBackAgain input
-              testCase "doesn't emit property for ValueNone"
-              <| fun _ ->
-                   let input = { OneOptionalStruct.RequiredName = "foo"; OptionalValue = ValueNone }
-                   let json = serialize input
-                   let prop = json |> tryGetProperty (nameof input.OptionalValue)
-                   Expect.isNone prop "OptionalValue with ValueNone should not get serialized"
-
-              ] ]
+                   json |> deserialize<AllOptional> |> ignore ] ]
 
       testList
         "U2"
@@ -311,7 +291,10 @@ let private serializationTests =
                let input = EU2("foo", 42)
 
                Expect.throws
-                 (fun _ -> serialize input |> ignore)
+                 (fun _ ->
+                   serialize input
+                   |> fun t -> printfn "%A" (t.ToString())
+                   |> ignore)
                  "ErasedUnion with multiple fields should not serializable"
           testCase "can (de)serialize struct union"
           <| fun _ ->

--- a/tests/Utils.fs
+++ b/tests/Utils.fs
@@ -1,0 +1,9 @@
+[<AutoOpen>]
+module Ionide.LanguageServerProtocol.Tests.Utils
+
+open Ionide.LanguageServerProtocol.Types
+
+let inline mkPos l c = { Line = l; Character = c }
+let inline mkRange s e = { Start = s; End = e }
+let inline mkRange' (sl, sc) (el, ec) = mkRange (mkPos sl sc) (mkPos el ec)
+let inline mkPosRange l c = mkRange (mkPos l c) (mkPos l c)


### PR DESCRIPTION
Currently `ErasedUnionConverter` doesn't implement [`ReadJson`](https://github.com/ionide/LanguageServerProtocol/blob/a5fdb53a482186f1f679e2d95ee2fabed0827a8b/src/LanguageServerProtocol.fs#L31) -> ErasedUnions cannot be deserialized from json.

But this is needed for [`inlayHint/resolve`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#inlayHint_resolve): input and output is `InlayHint` -> `InlayHint` must be serializable as well as deserializable. 


This PR implements `ReadJson` for `ErasedUnionConverter` -> enables deserialization of Erased Unions (and as a result deserialization of `InlayHint`) :
```fsharp
[<ErasedUnion>]
type U =
| String of string
| Data of {| Name: string; Value: int |}

(JToken.Parse "\"text\"" |> deserialize<U>) = U.String "text"
(JToken.Parse """{ "name":"foo", "value":42 }""" |> deserialize<U>) = U.Data {| Name = "foo"; Value = 42 |}
```

But note: This only works when types in each Union case are distinguishable from each other.  
For example: `U<float, int>` -> always deserializes to first Case because a number always matches float.

<br/>

There are some additional deserialization enhancements to match correct cases:

**Stricter basic type deserializing**

By default Newtonsoft.Json is rather lax when deserializing -> types must not match exactly. For example: `"42"` deserializes to `int`, and `42` deserializes successful to `string`.
This is an issue with Erased Union like `U2<int, string>` -> `"42"` gets deserialized as `U2.First 42` instead of `U2.Second "42"`  
This PR adds extra converters for `string`, `bool` and numbers so these cases get deserialized correctly.


**Proper handling of optional & required fields in Records**

Currently all fields are optional in practice -> field missing in json still deserializes to object:
```fsharp
type R = { Name: string; Value: int }
let json = """{ value: 42 }"""
let r = JToken.Parse json |> deserialize<R>
```
This works, but `r.Name` is `null`.

That's especially an issue for matching Cases in Erased Unions: every json objects can be deserialized into any record. For example `{}` can be deserialized into `R`. And in Union: `U2<R, {| MyValue: int |}>` -> `Second` never gets matched, because every json object fits `R`. So json `{"myValue": 42}` gets deserialized to `U2.First {R.Name=null; Value=0}`.

I added a custom ContractResolver, which ensures something can only be deserialized when all required fields exists.  
Option fields (`: _ option`) are optional and don't need to be present in json:
```fsharp
type S = { Name: string; Value: int option }
```
```json
{}                              // error: missing name
{ "name": "foo"}                // ok: name exists, value is optional
{ "name": "foo", "value": 42 }  // ok
{ "value": 42 }                 // error: missing name
{ "name": "foo", "bar": "baz"}  // ok: name exists, value is optional, additional properties get ignored
```
-> `U2<S, {|MyValue: int|}>` can be correctly deserialized

Note: Cases in Erased Unions still must be distinguishable from each other:  
`U2<S, {| Name: string; Something: int |}>` still gets always deserialized to `U2.First` (`S`) because `Name` is required in `S` while `Value` isn't -- and additional fields get ignored -> every json object with property `name` can be deserialized to `S`

Note: I do this by overwriting `Required` property for contracts. That means: I currently also overwrite custom required annotations specified in Attribute for a field (`[<JsonProperty(Required = ...)>]`) (Currently never used here in this Repo)  
-> Required and Optional is solely based on `option`.  

Note: Doesn't work with `ValueOption` (Supporting `voption` would require custom deserialize for ValueOption -- which is surprisingly complex (compared to `Option` (-> None=null -> handled by Newtonsoft))) ... and I didn't consider it necessary (currently not used in this repo))


<br/>
<br/>

**Note on speed of `ErasedUnionConverter`**:  
The converter tries to deserializes the current json value to each case in order. When one case doesn't fit json, deserializing this case throws an exception, which the converter catches and tries the next case.  
But exceptions are quite slow -> **put most likely case first** (`U2<LikelyUsed, UnlikelyUsed>`)  
And additional there's special handling for basic types (string, bool, numbers) -> get handled without exceptions -> **put case with basic type first** (`U2<int, MyRecord>`)


<br/>
<br/>

-------------------------------

<br/>
<br/>

Additional: 

**Add Tests**  
mostly targeting Converters and ContractResolver (-> Required/Optional). But not a complete test suite -- just the examples I used to implement this PR.  
* Tests are not hooked into any build process. 
* To run: `dotnet run --project tests`

**Add very simple benchmarks**  
Extremely basic benchmarks I used to measure speed (and allocations). Currently just serialize and deserialize back again of two large_ish (in terms of property count) LSP types (`InitializeParams` & `InlayHint`).  
It's questionable how representative these two actually are (InitParams is just used once in LSP lifecycle...), but I wanted to test with something with a lot of properties that cover a couple of different deserialization cases (and `InlayHint` is the reason for this PR).
* Currently located inside test project (just evolved naturally -- and I didn't refactor it...)
* Can be switched on with `--benchmarks` switch:
  `dotnet run --project tests -c Release -- --benchmarks --filter "*"`


<br/>
<br/>

-------------------------------

<br/>
<br/>

Because of additional project:  
Github Workflow files required updates to just process `./src` and ignore `./tests`. I *think* I adjusted all case -- but be sure to check again!