### PR TITLE
Remove spurious whitespace in workspace/executeCommand handler

### DIFF
--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -358,7 +358,7 @@ module Server =
       "workspace/willDeleteFiles", requestHandling (fun s p -> s.WorkspaceWillDeleteFiles(p))
       "workspace/didDeleteFiles", requestHandling (fun s p -> s.WorkspaceDidDeleteFiles(p) |> notificationSuccess)
       "workspace/symbol", requestHandling (fun s p -> s.WorkspaceSymbol(p))
-      "workspace/executeCommand ", requestHandling (fun s p -> s.WorkspaceExecuteCommand(p))
+      "workspace/executeCommand", requestHandling (fun s p -> s.WorkspaceExecuteCommand(p))
       "shutdown", requestHandling (fun s () -> s.Shutdown() |> notificationSuccess)
       "exit", requestHandling (fun s () -> s.Exit() |> notificationSuccess) ]
     |> Map.ofList


### PR DESCRIPTION
I was getting `No method by the name 'workspace/executeCommand' is found.` even though I registered all the providers correctly.

This seems like a good candidate for a reason why :)