### PR TITLE
More precise types for client and server rename capabilities

### DIFF
--- a/src/Types.fs
+++ b/src/Types.fs
@@ -709,6 +709,19 @@ type InlayHintClientCapabilities =
     /// hint.
     ResolveSupport: InlayHintClientCapabilitiesResolveSupport option }
 
+type RenameClientCapabilities =
+  { /// Whether rename supports dynamic registration.
+    DynamicRegistration: bool option
+    /// Client supports testing for validity of rename operations before execution.
+    /// @since version 3.12.0
+    PrepareSupport: bool option
+    /// Whether the client honors the change annotations in text edits and resource operations
+    /// returned via the rename request's workspace edit by for example presenting the workspace
+    /// edit in the user interface and asking for confirmation.
+    ///
+    /// @since 3.16.0
+    HonorsChangeAnnotations: bool option }
+
 /// Text document specific client capabilities.
 type TextDocumentClientCapabilities =
   { Synchronization: SynchronizationCapabilities option
@@ -756,7 +769,7 @@ type TextDocumentClientCapabilities =
     DocumentLink: DynamicCapabilities option
 
     /// Capabilities specific to the `textDocument/rename`
-    Rename: DynamicCapabilities option
+    Rename: RenameClientCapabilities option
 
     /// Capabilities for the `textDocument/foldingRange`
     FoldingRange: FoldingRangeCapabilities option
@@ -989,6 +1002,13 @@ type WorkspaceServerCapabilities =
     FileOperations: WorkspaceFileOperationsServerCapabilities option }
   static member Default = { WorkspaceFolders = None; FileOperations = None }
 
+
+/// RenameOptions may only be specified if the client states that it supports prepareSupport in its
+/// initial initialize request.
+type RenameOptions =
+  { /// Renames should be checked and tested before being executed.
+    PrepareProvider: bool option }
+
 type ServerCapabilities =
   { /// Defines how text documents are synced. Is either a detailed structure defining each notification or
     /// for backwards compatibility the TextDocumentSyncKind number.
@@ -1040,7 +1060,7 @@ type ServerCapabilities =
     DocumentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions option
 
     /// The server provides rename support.
-    RenameProvider: bool option
+    RenameProvider: U2<bool, RenameOptions> option
 
     /// The server provides document link support.
     DocumentLinkProvider: DocumentLinkOptions option


### PR DESCRIPTION
This is a continuation to #30. Apparently, nvim and emacs treat rename
capabilities a bit differently which is why I didn't notice the problem
before I tried using Marksman with Emacs.

https://github.com/artempyanykh/marksman/pull/40