### PR TITLE
Add Error.RequestCancelled*() and LspResult.requestCancelled<'a>

### DIFF
--- a/src/JsonRpc.fs
+++ b/src/JsonRpc.fs
@@ -48,6 +48,7 @@ module ErrorCodes =
   let internalError = -32603
   let serverErrorStart = -32000
   let serverErrorEnd = -32099
+  let requestCancelled = -32800
 
 type Error =
   { Code: int
@@ -60,6 +61,8 @@ type Error =
   static member InvalidParams = Error.Create(ErrorCodes.invalidParams, "Invalid params")
   static member InternalError = Error.Create(ErrorCodes.internalError, "Internal error")
   static member InternalErrorMessage message = Error.Create(ErrorCodes.internalError, message)
+  static member RequestCancelled = Error.Create(ErrorCodes.requestCancelled, "Request cancelled")
+  static member RequestCancelledMessage message = Error.Create(ErrorCodes.requestCancelled, message)
 
 type Response =
   { [<JsonProperty("jsonrpc")>]

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -30,6 +30,8 @@ module LspResult =
 
   let notImplemented<'a> : LspResult<'a> = Result.Error(JsonRpc.Error.MethodNotFound)
 
+  let requestCancelled<'a> : LspResult<'a> = Result.Error(JsonRpc.Error.RequestCancelled)
+
 module AsyncLspResult =
   open Ionide.LanguageServerProtocol
 


### PR DESCRIPTION
I am using this in csharp-ls to report cancellation-on-timeout from certain non-critical endpoints, e.g. "codeLens/resolve" where it takes too long for it to respond and I don't want to burn too much CPU and improve responsiveness.