### PR TITLE
Avoid server crash when handler returns LspResult.Error

### DIFF
--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -90,7 +90,11 @@ module Server =
     // and thus any exception that happens during e.g. text sync gets swallowed.
     use jsonRpc =
       { new JsonRpc(jsonRpcHandler) with
-          member this.IsFatalException(ex: Exception) = true }
+          member this.IsFatalException(ex: Exception) =
+              match ex with
+              | :? LocalRpcException -> false
+              | _ -> true
+      }
 
     /// When the server wants to send a notification to the client
     let sendServerNotification (rpcMethod: string) (notificationObj: obj) : AsyncLspResult<unit> =


### PR DESCRIPTION
It appears that https://github.com/ionide/LanguageServerProtocol/pull/29 broke the reporting of LspResult.Error to StreamJsonRpc.

StreamJsonRpc processes LocalRpcException to report exceptions/errors from request handlers. In particular we have code in `requestHandling` that actually throws LocalRcpException when handler returns LspResult.Error.

This commit adds code to skip marking LocalRcpException as a fatal exception and make it not crash the server.

FYI @artempyanykh