### PR TITLE
Make PublishDiagnostics optional

### DIFF
--- a/src/Types.fs
+++ b/src/Types.fs
@@ -777,7 +777,7 @@ type TextDocumentClientCapabilities =
   { Synchronization: SynchronizationCapabilities option
 
     /// Capabilities specific to `textDocument/publishDiagnostics`.
-    PublishDiagnostics: PublishDiagnosticsCapabilities
+    PublishDiagnostics: PublishDiagnosticsCapabilities option
 
     /// Capabilities specific to the `textDocument/completion`
     Completion: CompletionCapabilities option

--- a/tests/Benchmarks.fs
+++ b/tests/Benchmarks.fs
@@ -412,7 +412,7 @@ type MultipleTypesBenchmarks() =
                         WillSave = Some true
                         WillSaveWaitUntil = Some false
                         DidSave = Some true }
-                  PublishDiagnostics = { RelatedInformation = None; TagSupport = None }
+                  PublishDiagnostics = Some { RelatedInformation = None; TagSupport = None }
                   Completion = None
                   Hover =
                     Some


### PR DESCRIPTION
### WHAT
Makes the PublishDiagnostics property optional. Some clients do not pass this property (Lapce)

### WHY
JsonDeSerialization crashes because of this => makes csharp-ls unusable with Lapce.
