### PR TITLE
Allow multiple instances of the server on a single process.

### DIFF
--- a/tests/Ionide.LanguageServerProtocol.Tests.fsproj
+++ b/tests/Ionide.LanguageServerProtocol.Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="Utils.fs" />
     <Compile Include="Benchmarks.fs" />
     <Compile Include="Shotgun.fs" />
+    <Compile Include="StartWithSetup.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/tests/StartWithSetup.fs
+++ b/tests/StartWithSetup.fs
@@ -1,0 +1,74 @@
+module Ionide.LanguageServerProtocol.Tests.StartWithSetup
+
+open Expecto
+open System.IO.Pipes
+open System.IO
+open Ionide.LanguageServerProtocol
+open Ionide.LanguageServerProtocol.Server
+
+type TestLspClient(sendServerNotification: ClientNotificationSender, sendServerRequest: ClientRequestSender) =
+    inherit LspClient ()
+
+let setupEndpoints(_: LspClient): Map<string, System.Delegate> =
+    [] |> Map.ofList
+
+let requestWithContentLength(request: string) =
+    @$"Content-Length: {request.Length}
+
+{request}"
+
+let shutdownRequest = @"{""jsonrpc"":""2.0"",""method"":""shutdown"",""id"":1}"
+
+let exitRequest = @"{""jsonrpc"":""2.0"",""method"":""exit"",""id"":1}"
+
+let tests =
+  testList
+    "startWithSetup"
+    [
+      testAsync "can start up multiple times in same process" {
+        use inputServerPipe1 = new AnonymousPipeServerStream()
+        use inputClientPipe1 = new AnonymousPipeClientStream(inputServerPipe1.GetClientHandleAsString())
+        use outputServerPipe1 = new AnonymousPipeServerStream()
+
+        use inputWriter1 = new StreamWriter(inputServerPipe1)
+        inputWriter1.AutoFlush <- true
+        let server1 = async {
+            let result = (startWithSetup
+                setupEndpoints
+                inputClientPipe1
+                outputServerPipe1
+                TestLspClient
+                defaultRpc)
+            Expect.equal (int result) 0 "server startup failed"
+        }
+        
+        let! server1Async = Async.StartChild(server1)
+        
+        use inputServerPipe2 = new AnonymousPipeServerStream()
+        use inputClientPipe2 = new AnonymousPipeClientStream(inputServerPipe2.GetClientHandleAsString())
+        use outputServerPipe2 = new AnonymousPipeServerStream()
+
+        use inputWriter2 = new StreamWriter(inputServerPipe2)
+        inputWriter2.AutoFlush <- true
+        let server2 = async {
+            let result = (startWithSetup
+                setupEndpoints
+                inputClientPipe2
+                outputServerPipe2
+                TestLspClient
+                defaultRpc)
+            Expect.equal (int result) 0 "server startup failed"
+        }
+        
+        let! server2Async = Async.StartChild(server2)
+        
+        inputWriter1.Write(requestWithContentLength(shutdownRequest))
+        inputWriter1.Write(requestWithContentLength(exitRequest))
+        
+        inputWriter2.Write(requestWithContentLength(shutdownRequest))
+        inputWriter2.Write(requestWithContentLength(exitRequest))
+
+        do! server1Async
+        do! server2Async
+      }
+    ]

--- a/tests/StartWithSetup.fs
+++ b/tests/StartWithSetup.fs
@@ -13,9 +13,7 @@ let setupEndpoints(_: LspClient): Map<string, System.Delegate> =
     [] |> Map.ofList
 
 let requestWithContentLength(request: string) =
-    @$"Content-Length: {request.Length}
-
-{request}"
+    $"Content-Length: {request.Length}\r\n\r\n{request}"
 
 let shutdownRequest = @"{""jsonrpc"":""2.0"",""method"":""shutdown"",""id"":1}"
 

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -874,7 +874,8 @@ let private serializationTests =
                     Data = None }
                testThereAndBackAgain item
         ]
-      Shotgun.tests ]
+      Shotgun.tests
+      StartWithSetup.tests ]
 
 [<Tests>]
 let tests = testList "LSP" [ serializationTests; Utils.tests ]


### PR DESCRIPTION
Addresses [issue](https://github.com/ionide/LanguageServerProtocol/issues/50).

Allows singleton json formatter for `serialize`/`deserialize`.

`startWithSetup` creates json formatter each time.