### PR TITLE
Fixing spellings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
   "editor.formatOnSave": true,
   "yaml.schemas": {
     "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json": ".github/workflows/**"
-  }
+  },
+  "cSpell.words": [
+    "Ionide",
+    "Newtonsoft",
+    "Supertypes"
+  ]
 }

--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -16,7 +16,7 @@ module Server =
 
   let logger = LogProvider.getLoggerByName "LSP Server"
 
-  let defaultJsonRpcFormatter() =
+  let defaultJsonRpcFormatter () =
     let jsonRpcFormatter = new JsonMessageFormatter()
     jsonRpcFormatter.JsonSerializer.NullValueHandling <- NullValueHandling.Ignore
     jsonRpcFormatter.JsonSerializer.ConstructorHandling <- ConstructorHandling.AllowNonPublicDefaultConstructor
@@ -30,7 +30,7 @@ module Server =
     jsonRpcFormatter.JsonSerializer.ContractResolver <- OptionAndCamelCasePropertyNamesContractResolver()
     jsonRpcFormatter
 
-  let jsonRpcFormatter = defaultJsonRpcFormatter()
+  let jsonRpcFormatter = defaultJsonRpcFormatter ()
 
   let deserialize<'t> (token: JToken) = token.ToObject<'t>(jsonRpcFormatter.JsonSerializer)
   let serialize<'t> (o: 't) = JToken.FromObject(o, jsonRpcFormatter.JsonSerializer)
@@ -99,7 +99,7 @@ module Server =
     (customizeRpc: IJsonRpcMessageHandler -> JsonRpc)
     =
 
-    use jsonRpcHandler = new HeaderDelimitedMessageHandler(output, input, defaultJsonRpcFormatter())
+    use jsonRpcHandler = new HeaderDelimitedMessageHandler(output, input, defaultJsonRpcFormatter ())
     // Without overriding isFatalException, JsonRpc serializes exceptions and sends them to the client.
     // This is particularly bad for notifications such as textDocument/didChange which don't require a response,
     // and thus any exception that happens during e.g. text sync gets swallowed.
@@ -234,12 +234,12 @@ module Server =
       "textDocument/linkedEditingRange", requestHandling (fun s p -> s.TextDocumentLinkedEditingRange(p))
       "textDocument/foldingRange", requestHandling (fun s p -> s.TextDocumentFoldingRange(p))
       "textDocument/selectionRange", requestHandling (fun s p -> s.TextDocumentSelectionRange(p))
-      "textDocument/prepareCallHierarchy", requestHandling(fun s p -> s.TextDocumentPrepareCallHierarchy(p))
-      "callHierarchy/incomingCalls", requestHandling(fun s p -> s.CallHierarchyIncomingCalls(p))
-      "callHierarchy/outgoingCalls", requestHandling(fun s p -> s.CallHierarchyOutgoingCalls(p))
-      "textDocument/prepareTypeHierarchy", requestHandling(fun s p -> s.TextDocumentPrepareTypeHierarchy(p))
-      "typeHierarchy/supertypes", requestHandling(fun s p -> s.TypeHierarchySupertypes(p))
-      "typeHierarchy/subtypes", requestHandling(fun s p -> s.TypeHierarchySubtypes(p))
+      "textDocument/prepareCallHierarchy", requestHandling (fun s p -> s.TextDocumentPrepareCallHierarchy(p))
+      "callHierarchy/incomingCalls", requestHandling (fun s p -> s.CallHierarchyIncomingCalls(p))
+      "callHierarchy/outgoingCalls", requestHandling (fun s p -> s.CallHierarchyOutgoingCalls(p))
+      "textDocument/prepareTypeHierarchy", requestHandling (fun s p -> s.TextDocumentPrepareTypeHierarchy(p))
+      "typeHierarchy/supertypes", requestHandling (fun s p -> s.TypeHierarchySupertypes(p))
+      "typeHierarchy/subtypes", requestHandling (fun s p -> s.TypeHierarchySubtypes(p))
       "textDocument/semanticTokens/full", requestHandling (fun s p -> s.TextDocumentSemanticTokensFull(p))
       "textDocument/semanticTokens/full/delta", requestHandling (fun s p -> s.TextDocumentSemanticTokensFullDelta(p))
       "textDocument/semanticTokens/range", requestHandling (fun s p -> s.TextDocumentSemanticTokensRange(p))
@@ -264,7 +264,7 @@ module Server =
       "workspace/symbol", requestHandling (fun s p -> s.WorkspaceSymbol(p))
       "workspaceSymbol/resolve", requestHandling (fun s p -> s.WorkspaceSymbolResolve(p))
       "workspace/executeCommand", requestHandling (fun s p -> s.WorkspaceExecuteCommand(p))
-      "window/workDoneProgress/cancel", requestHandling (fun s p -> s.WorkDoneProgessCancel(p) |> notificationSuccess)
+      "window/workDoneProgress/cancel", requestHandling (fun s p -> s.WorkDoneProgressCancel(p) |> notificationSuccess)
       "workspace/diagnostic", requestHandling (fun s p -> s.WorkspaceDiagnostic(p))
       "shutdown", requestHandling (fun s () -> s.Shutdown() |> notificationSuccess)
       "exit", requestHandling (fun s () -> s.Exit() |> notificationSuccess) ]

--- a/src/Server.fs
+++ b/src/Server.fs
@@ -83,7 +83,7 @@ type ILspServer =
 
 
   /// The go to declaration request is sent from the client to the server to resolve the declaration location
-  /// of a synbol at a given text document position
+  /// of a symbol at a given text document position
   abstract member TextDocumentDeclaration: TextDocumentPositionParams -> AsyncLspResult<GotoResult option>
 
   /// The goto definition request is sent from the client to the server to resolve the definition location of
@@ -199,7 +199,8 @@ type ILspServer =
   /// returned to describe valid contents. A rename to one of the ranges can be applied to all other ranges if the new
   /// content is valid. If no result-specific word pattern is provided, the word pattern from the client’s language
   /// configuration is used.
-  abstract member TextDocumentLinkedEditingRange: TextDocumentPositionParams -> AsyncLspResult<LinkedEditingRanges option>
+  abstract member TextDocumentLinkedEditingRange:
+    TextDocumentPositionParams -> AsyncLspResult<LinkedEditingRanges option>
 
 
   /// The watched files notification is sent from the client to the server when the client detects changes
@@ -211,7 +212,7 @@ type ILspServer =
 
   /// The `workspace/didChangeWorkspaceFolders` notification is sent from the client to the server to inform
   /// the server about workspace folder configuration changes. The notification is sent by default if both
-  /// *ServerCapabilities/workspace/workspaceFolders* and *ClientCapabilities/workapce/workspaceFolders* are
+  /// *ServerCapabilities/workspace/workspaceFolders* and *ClientCapabilities/workspace/workspaceFolders* are
   /// true; or if the server has registered to receive this notification it first.
   abstract member WorkspaceDidChangeWorkspaceFolders: DidChangeWorkspaceFoldersParams -> Async<unit>
 
@@ -254,7 +255,8 @@ type ILspServer =
 
   /// The workspace symbol request is sent from the client to the server to list project-wide symbols matching
   /// the query string.
-  abstract member WorkspaceSymbol: WorkspaceSymbolParams -> AsyncLspResult<U2<SymbolInformation [], WorkspaceSymbol []> option>
+  abstract member WorkspaceSymbol:
+    WorkspaceSymbolParams -> AsyncLspResult<U2<SymbolInformation [], WorkspaceSymbol []> option>
 
 
   /// The request is sent from the client to the server to resolve additional information for a given workspace symbol.
@@ -325,9 +327,9 @@ type ILspServer =
   /// progress initiated on the server side using the `window/workDoneProgress/create`. The progress need
   /// not be marked as cancellable to be cancelled and a client may cancel a progress for any number of
   /// reasons: in case of error, reloading a workspace etc.
-  abstract member WorkDoneProgessCancel: ProgressToken -> Async<unit>
+  abstract member WorkDoneProgressCancel: ProgressToken -> Async<unit>
 
-  /// The inline value request is sent from the client to the server to compute inline values for a given text document 
+  /// The inline value request is sent from the client to the server to compute inline values for a given text document
   /// that may be rendered in the editor at the end of lines.
   abstract member TextDocumentInlineValue: InlineValueParams -> AsyncLspResult<InlineValue [] option>
 
@@ -336,24 +338,28 @@ type ILspServer =
   /// steps:
   /// 1. first a call hierarchy item is resolved for the given text document position
   /// 2. for a call hierarchy item the incoming or outgoing call hierarchy items are resolved.
-  abstract member TextDocumentPrepareCallHierarchy: CallHierarchyPrepareParams -> AsyncLspResult<CallHierarchyItem [] option>
+  abstract member TextDocumentPrepareCallHierarchy:
+    CallHierarchyPrepareParams -> AsyncLspResult<CallHierarchyItem [] option>
 
   /// The request is sent from the client to the server to resolve incoming calls for a given call hierarchy
   /// item. The request doesn't define its own client and server capabilities. It is only issued if a server
   /// registers for the `textDocument/prepareCallHierarchy` request.
-  abstract member CallHierarchyIncomingCalls: CallHierarchyIncomingCallsParams -> AsyncLspResult<CallHierarchyIncomingCall [] option>
+  abstract member CallHierarchyIncomingCalls:
+    CallHierarchyIncomingCallsParams -> AsyncLspResult<CallHierarchyIncomingCall [] option>
 
   /// The request is sent from the client to the server to resolve outgoing calls for a given call hierarchy
   /// item. The request doesn't define its own  client and server capabilities. It is only issued if a server
   /// registers for the `textDocument/prepareCallHierarchy` request.
-  abstract member CallHierarchyOutgoingCalls: CallHierarchyOutgoingCallsParams -> AsyncLspResult<CallHierarchyOutgoingCall [] option>
+  abstract member CallHierarchyOutgoingCalls:
+    CallHierarchyOutgoingCallsParams -> AsyncLspResult<CallHierarchyOutgoingCall [] option>
 
   /// The type hierarchy request is sent from the client to the server to return a type hierarchy for the
   /// language element of given text document positions. Will return `null` if the server couldn't infer a
   /// valid type from the position. The type hierarchy requests are executed in two steps:
   /// 1. first a type hierarchy item is prepared for the given text document position.
   /// 2. for a type hierarchy item the supertype or subtype type hierarchy items are resolved.
-  abstract member TextDocumentPrepareTypeHierarchy: TypeHierarchyPrepareParams -> AsyncLspResult<TypeHierarchyItem [] option>
+  abstract member TextDocumentPrepareTypeHierarchy:
+    TypeHierarchyPrepareParams -> AsyncLspResult<TypeHierarchyItem [] option>
 
   /// The request is sent from the client to the server to resolve the supertype for a given type hierarchy
   /// item. Will return `null` is the serve couldn't infer a valid type from `item` in the params. The request
@@ -468,6 +474,7 @@ type LspServer() =
   /// The go to declaration request is sent from the client to the server to resolve the declaration location
   /// of a symbol at a given text document position.
   abstract member TextDocumentDeclaration: TextDocumentPositionParams -> AsyncLspResult<GotoResult option>
+
   default __.TextDocumentDeclaration(_) = notImplemented
 
   /// The goto definition request is sent from the client to the server to resolve the definition location of
@@ -603,7 +610,8 @@ type LspServer() =
   /// returned to describe valid contents. A rename to one of the ranges can be applied to all other ranges if the new
   /// content is valid. If no result-specific word pattern is provided, the word pattern from the client’s language
   /// configuration is used.
-  abstract member TextDocumentLinkedEditingRange: TextDocumentPositionParams -> AsyncLspResult<LinkedEditingRanges option>
+  abstract member TextDocumentLinkedEditingRange:
+    TextDocumentPositionParams -> AsyncLspResult<LinkedEditingRanges option>
 
   default __.TextDocumentLinkedEditingRange(_) = notImplemented
 
@@ -617,7 +625,7 @@ type LspServer() =
 
   /// The `workspace/didChangeWorkspaceFolders` notification is sent from the client to the server to inform
   /// the server about workspace folder configuration changes. The notification is sent by default if both
-  /// *ServerCapabilities/workspace/workspaceFolders* and *ClientCapabilities/workapce/workspaceFolders* are
+  /// *ServerCapabilities/workspace/workspaceFolders* and *ClientCapabilities/workspace/workspaceFolders* are
   /// true; or if the server has registered to receive this notification it first.
   abstract member WorkspaceDidChangeWorkspaceFolders: DidChangeWorkspaceFoldersParams -> Async<unit>
 
@@ -668,7 +676,8 @@ type LspServer() =
 
   /// The workspace symbol request is sent from the client to the server to list project-wide symbols matching
   /// the query string.
-  abstract member WorkspaceSymbol: WorkspaceSymbolParams -> AsyncLspResult<U2<SymbolInformation [], WorkspaceSymbol []> option>
+  abstract member WorkspaceSymbol:
+    WorkspaceSymbolParams -> AsyncLspResult<U2<SymbolInformation [], WorkspaceSymbol []> option>
 
   default __.WorkspaceSymbol(_) = notImplemented
 
@@ -755,13 +764,14 @@ type LspServer() =
   /// progress initiated on the server side using the `window/workDoneProgress/create`. The progress need
   /// not be marked as cancellable to be cancelled and a client may cancel a progress for any number of
   /// reasons: in case of error, reloading a workspace etc.
-  abstract member WorkDoneProgessCancel: ProgressToken -> Async<unit>
+  abstract member WorkDoneProgressCancel: ProgressToken -> Async<unit>
 
-  default __.WorkDoneProgessCancel(_) = ignoreNotification
+  default __.WorkDoneProgressCancel(_) = ignoreNotification
 
-  /// The inline value request is sent from the client to the server to compute inline values for a given text document 
+  /// The inline value request is sent from the client to the server to compute inline values for a given text document
   /// that may be rendered in the editor at the end of lines.
   abstract member TextDocumentInlineValue: InlineValueParams -> AsyncLspResult<InlineValue [] option>
+
   default __.TextDocumentInlineValue(_) = notImplemented
 
   /// The call hierarchy request is sent from the client to the server to return a call hierarchy for the
@@ -769,19 +779,25 @@ type LspServer() =
   /// steps:
   /// 1. first a call hierarchy item is resolved for the given text document position
   /// 2. for a call hierarchy item the incoming or outgoing call hierarchy items are resolved.
-  abstract member TextDocumentPrepareCallHierarchy: CallHierarchyPrepareParams -> AsyncLspResult<CallHierarchyItem [] option>
+  abstract member TextDocumentPrepareCallHierarchy:
+    CallHierarchyPrepareParams -> AsyncLspResult<CallHierarchyItem [] option>
+
   default __.TextDocumentPrepareCallHierarchy(_) = notImplemented
 
   /// The request is sent from the client to the server to resolve incoming calls for a given call hierarchy
   /// item. The request doesn't define its own client and server capabilities. It is only issued if a server
   /// registers for the `textDocument/prepareCallHierarchy` request.
-  abstract member CallHierarchyIncomingCalls: CallHierarchyIncomingCallsParams -> AsyncLspResult<CallHierarchyIncomingCall [] option>
+  abstract member CallHierarchyIncomingCalls:
+    CallHierarchyIncomingCallsParams -> AsyncLspResult<CallHierarchyIncomingCall [] option>
+
   default __.CallHierarchyIncomingCalls(_) = notImplemented
 
   /// The request is sent from the client to the server to resolve outgoing calls for a given call hierarchy
   /// item. The request doesn't define its own  client and server capabilities. It is only issued if a server
   /// registers for the `textDocument/prepareCallHierarchy` request.
-  abstract member CallHierarchyOutgoingCalls: CallHierarchyOutgoingCallsParams -> AsyncLspResult<CallHierarchyOutgoingCall [] option>
+  abstract member CallHierarchyOutgoingCalls:
+    CallHierarchyOutgoingCallsParams -> AsyncLspResult<CallHierarchyOutgoingCall [] option>
+
   default __.CallHierarchyOutgoingCalls(_) = notImplemented
 
   /// The type hierarchy request is sent from the client to the server to return a type hierarchy for the
@@ -789,7 +805,9 @@ type LspServer() =
   /// valid type from the position. The type hierarchy requests are executed in two steps:
   /// 1. first a type hierarchy item is prepared for the given text document position.
   /// 2. for a type hierarchy item the supertype or subtype type hierarchy items are resolved.
-  abstract member TextDocumentPrepareTypeHierarchy: TypeHierarchyPrepareParams -> AsyncLspResult<TypeHierarchyItem [] option>
+  abstract member TextDocumentPrepareTypeHierarchy:
+    TypeHierarchyPrepareParams -> AsyncLspResult<TypeHierarchyItem [] option>
+
   default __.TextDocumentPrepareTypeHierarchy(_) = notImplemented
 
   /// The request is sent from the client to the server to resolve the supertype for a given type hierarchy
@@ -797,6 +815,7 @@ type LspServer() =
   /// doesn't defines its own client and server capabilities. It is only issued if a server registers for the
   /// `textDocument/prepareTypeHierarchy` request.
   abstract member TypeHierarchySupertypes: TypeHierarchySupertypesParams -> AsyncLspResult<TypeHierarchyItem [] option>
+
   default __.TypeHierarchySupertypes(_) = notImplemented
 
   /// The request is sent from the client to the server to resolve the supertype for a given type hierarchy
@@ -804,6 +823,7 @@ type LspServer() =
   /// doesn't defines its own client and server capabilities. It is only issued if a server registers for the
   /// `textDocument/prepareTypeHierarchy` request.
   abstract member TypeHierarchySubtypes: TypeHierarchySubtypesParams -> AsyncLspResult<TypeHierarchyItem [] option>
+
   default __.TypeHierarchySubtypes(_) = notImplemented
 
   /// The text document diagnostic request is sent from the client to the server to ask the server to compute
@@ -888,14 +908,18 @@ type LspServer() =
     member this.TextDocumentSemanticTokensRange(p: SemanticTokensRangeParams) = this.TextDocumentSemanticTokensRange(p)
     member this.TextDocumentInlayHint(p: InlayHintParams) = this.TextDocumentInlayHint(p)
     member this.InlayHintResolve(p: InlayHint) = this.InlayHintResolve(p)
-    member this.WorkDoneProgessCancel(token) = this.WorkDoneProgessCancel(token)
+    member this.WorkDoneProgressCancel(token) = this.WorkDoneProgressCancel(token)
     member this.TextDocumentInlineValue(p: InlineValueParams) = this.TextDocumentInlineValue(p)
 
-    member this.TextDocumentPrepareCallHierarchy(p: CallHierarchyPrepareParams) = this.TextDocumentPrepareCallHierarchy(p)
+    member this.TextDocumentPrepareCallHierarchy(p: CallHierarchyPrepareParams) =
+      this.TextDocumentPrepareCallHierarchy(p)
+
     member this.CallHierarchyIncomingCalls(p: CallHierarchyIncomingCallsParams) = this.CallHierarchyIncomingCalls(p)
     member this.CallHierarchyOutgoingCalls(p: CallHierarchyOutgoingCallsParams) = this.CallHierarchyOutgoingCalls(p)
 
-    member this.TextDocumentPrepareTypeHierarchy(p: TypeHierarchyPrepareParams) = this.TextDocumentPrepareTypeHierarchy(p)
+    member this.TextDocumentPrepareTypeHierarchy(p: TypeHierarchyPrepareParams) =
+      this.TextDocumentPrepareTypeHierarchy(p)
+
     member this.TypeHierarchySupertypes(p: TypeHierarchySupertypesParams) = this.TypeHierarchySupertypes(p)
     member this.TypeHierarchySubtypes(p: TypeHierarchySubtypesParams) = this.TypeHierarchySubtypes(p)
     member this.TextDocumentDiagnostic(p: DocumentDiagnosticParams) = this.TextDocumentDiagnostic(p)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1cf760</samp>

This pull request improves the code style, readability, and documentation of the `LanguageServerProtocol` and `Server` modules in `src/LanguageServerProtocol.fs` and `src/Server.fs`, and adds some project-specific words to the cSpell ignore list in `.vscode/settings.json`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e1cf760</samp>

> _Sing, O Muse, of the valiant F# coders who strive to perfect their craft_
> _With cSpell they check their words, lest they incur the extension's wrath_
> _But some words they must exclude, like Ionide or Newtonsoft_
> _For these are the names of mighty tools, not errors to be fixed_

<!--
copilot:emoji
-->

:memo::art::pencil2:

<!--
1.  :memo: - This emoji is often used to indicate changes or updates to documentation, which is the case for the first change that modifies the `.vscode/settings.json` file to configure the cSpell extension. This change does not affect the functionality or behavior of the code, but rather the development tools and environment.
2. :art: - This emoji is often used to indicate changes that improve the code style, format, or structure, which is the case for the second change that adds spaces before parentheses in the `Server` module. This change does not affect the functionality or behavior of the code, but rather the appearance and consistency.
3. :pencil2: - This emoji is often used to indicate changes that fix typos, grammar, or spelling errors, which is the case for the third change that corrects some mistakes and breaks some long lines in the comments and signatures of the `ILspServer` and `LspServer` types. This change does not affect the functionality or behavior of the code, but rather the accuracy and clarity of the documentation.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1cf760</samp>

*  Add a new setting to ignore some words by the cSpell extension in `.vscode/settings.json` ([link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R5-R9))
*  Add spaces before parentheses when calling functions with no arguments to follow the F# style guide in `src/LanguageServerProtocol.fs` and `src/Server.fs` ([link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L19-R19), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L33-R33), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L102-R102), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L237-R242), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L267-R267), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0R477), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L758-R774))
*  Break long lines after colons in signatures of abstract members and members with complex return types to improve readability in `src/Server.fs` ([link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L202-R203), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L257-R259), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L339-R354), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L356-R362), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L606-R614), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L772-R784), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L778-R792), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L784-R800), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L792-R810), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L891-R925))
*  Fix typos in comments for abstract members in `src/Server.fs` ([link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L86-R86), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L214-R215), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L328-R332), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0L620-R628))
*  Add blank lines after the end of type, module, and member definitions to follow the F# style guide in `src/Server.fs` ([link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0R477), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0R818), [link](https://github.com/ionide/LanguageServerProtocol/pull/54/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0R826))
