### PR TITLE
Fix crashing on json serialization

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,8 +8,8 @@
         "paket"
       ]
     },
-    "fantomas-tool": {
-      "version": "4.7.8",
+    "fantomas": {
+      "version": "6.2.2",
       "commands": [
         "fantomas"
       ]

--- a/tests/StartWithSetup.fs
+++ b/tests/StartWithSetup.fs
@@ -5,68 +5,101 @@ open System.IO.Pipes
 open System.IO
 open Ionide.LanguageServerProtocol
 open Ionide.LanguageServerProtocol.Server
+open Nerdbank.Streams
+open StreamJsonRpc
+open System
+open System.Reflection
+open StreamJsonRpc.Protocol
 
 type TestLspClient(sendServerNotification: ClientNotificationSender, sendServerRequest: ClientRequestSender) =
-    inherit LspClient ()
+  inherit LspClient()
 
-let setupEndpoints(_: LspClient): Map<string, System.Delegate> =
-    [] |> Map.ofList
+let setupEndpoints (_: LspClient) : Map<string, System.Delegate> = [] |> Map.ofList
 
-let requestWithContentLength(request: string) =
-    $"Content-Length: {request.Length}\r\n\r\n{request}"
+let requestWithContentLength (request: string) = $"Content-Length: {request.Length}\r\n\r\n{request}"
 
 let shutdownRequest = @"{""jsonrpc"":""2.0"",""method"":""shutdown"",""id"":1}"
 
 let exitRequest = @"{""jsonrpc"":""2.0"",""method"":""exit"",""id"":1}"
 
+
+type Foo = { bar: string; baz: string }
+
 let tests =
   testList
     "startWithSetup"
-    [
-      testAsync "can start up multiple times in same process" {
+    [ testAsync "can start up multiple times in same process" {
         use inputServerPipe1 = new AnonymousPipeServerStream()
         use inputClientPipe1 = new AnonymousPipeClientStream(inputServerPipe1.GetClientHandleAsString())
         use outputServerPipe1 = new AnonymousPipeServerStream()
 
         use inputWriter1 = new StreamWriter(inputServerPipe1)
         inputWriter1.AutoFlush <- true
-        let server1 = async {
-            let result = (startWithSetup
-                setupEndpoints
-                inputClientPipe1
-                outputServerPipe1
-                TestLspClient
-                defaultRpc)
+
+        let server1 =
+          async {
+            let result = (startWithSetup setupEndpoints inputClientPipe1 outputServerPipe1 TestLspClient defaultRpc)
             Expect.equal (int result) 0 "server startup failed"
-        }
-        
+          }
+
         let! server1Async = Async.StartChild(server1)
-        
+
         use inputServerPipe2 = new AnonymousPipeServerStream()
         use inputClientPipe2 = new AnonymousPipeClientStream(inputServerPipe2.GetClientHandleAsString())
         use outputServerPipe2 = new AnonymousPipeServerStream()
 
         use inputWriter2 = new StreamWriter(inputServerPipe2)
         inputWriter2.AutoFlush <- true
-        let server2 = async {
-            let result = (startWithSetup
-                setupEndpoints
-                inputClientPipe2
-                outputServerPipe2
-                TestLspClient
-                defaultRpc)
+
+        let server2 =
+          async {
+            let result = (startWithSetup setupEndpoints inputClientPipe2 outputServerPipe2 TestLspClient defaultRpc)
             Expect.equal (int result) 0 "server startup failed"
-        }
-        
+          }
+
         let! server2Async = Async.StartChild(server2)
-        
-        inputWriter1.Write(requestWithContentLength(shutdownRequest))
-        inputWriter1.Write(requestWithContentLength(exitRequest))
-        
-        inputWriter2.Write(requestWithContentLength(shutdownRequest))
-        inputWriter2.Write(requestWithContentLength(exitRequest))
+
+        inputWriter1.Write(requestWithContentLength (shutdownRequest))
+        inputWriter1.Write(requestWithContentLength (exitRequest))
+
+        inputWriter2.Write(requestWithContentLength (shutdownRequest))
+        inputWriter2.Write(requestWithContentLength (exitRequest))
 
         do! server1Async
         do! server2Async
       }
-    ]
+
+      testCaseAsync "Handle JsonSerializationError gracefully"
+      <| async {
+
+        let struct (server, client) = FullDuplexStream.CreatePair()
+
+        use jsonRpcHandler = new HeaderDelimitedMessageHandler(server, defaultJsonRpcFormatter ())
+        use serverRpc = defaultRpc jsonRpcHandler
+
+        let functions: Map<string, Delegate> = Map [ "lol", Func<Foo, Foo>(fun (foo: Foo) -> foo) :> Delegate ]
+
+        functions
+        |> Seq.iter (fun (KeyValue(name, rpcDelegate)) ->
+          let rpcAttribute = JsonRpcMethodAttribute(name)
+          rpcAttribute.UseSingleObjectParameterDeserialization <- true
+          serverRpc.AddLocalRpcMethod(rpcDelegate.GetMethodInfo(), rpcDelegate.Target, rpcAttribute))
+
+        serverRpc.StartListening()
+        let create (s: Stream) : JsonRpc = JsonRpc.Attach(s, target = null)
+        let clientRpc: JsonRpc = create client
+
+        try
+          let! (_: Foo) =
+            clientRpc.InvokeWithParameterObjectAsync<Foo>("lol", {| bar = "lol" |})
+            |> Async.AwaitTask
+
+          ()
+        with Flatten(:? RemoteInvocationException as ex) ->
+          Expect.equal
+            ex.Message
+            "Required property 'baz' not found in JSON. Path ''."
+            "Get parse error message and not crash process"
+
+          Expect.equal ex.ErrorCode ((int) JsonRpcErrorCode.ParseError) "Should get parse error code"
+      } ]


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 363f2ce</samp>

The pull request enhances the error handling and robustness of the LanguageServerProtocol library and its tests, using StreamJsonRpc types and methods and following the Fantomas style. It also updates the fantomas-tool package name and version in `dotnet-tools.json`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 363f2ce</samp>

> _To avoid any naming mishaps_
> _We updated the package `fantomas`_
> _We also revised_
> _The `Server` and `Client` sides_
> _And added some tests and new RPCs_

<!--
copilot:emoji
-->

:package::wrench::white_check_mark:

<!--
1.  :package: - This emoji represents the change of the package name and version, and indicates that it is related to packaging and distribution.
2.  :wrench: - This emoji represents the changes to the Server and Client modules, and indicates that they are related to fixing and improving the functionality and performance of the tool.
3.  :white_check_mark: - This emoji represents the addition of a new test case and a new RPC method, and indicates that they are related to testing and verifying the correctness and quality of the code.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 363f2ce</samp>

*  Update fantomas-tool package name and version to fantomas 6.2.2 in `.config/dotnet-tools.json` ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L11-R12))
*  Add open statements for StreamJsonRpc, JsonRpc, and StreamJsonRpc.Protocol namespaces in `src/LanguageServerProtocol.fs` ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9R16-R17))
*  Add (|Flatten|) active pattern and flatten function to handle AggregateExceptions in Server module ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L85-R126))
*  Use flatten function in IsFatalException and CreateErrorDetails methods of defaultRpc function ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L273-R307))
*  Reformat start function in Server module to break line after generic type parameters and remove extra parentheses ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L273-R307))
*  Change catch clauses from using vertical bar to arrow in Client module ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L328-R363), [link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L456-R490), [link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L475-R509), [link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L560-R593))
*  Reformat MailboxProcessor.Start function call and loop function in mutable function in Client module ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-e8b1cdcb9bc744e4631def23ffbb4516012e5217882e1a32eb5e9d0cc68e56c9L427-R475))
*  Add open statements for Nerdbank.Streams, StreamJsonRpc, System, System.Reflection, and StreamJsonRpc.Protocol namespaces in `tests/StartWithSetup.fs` ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-68fe8350fe78602fb8fe7b610e6b7d0ad0314bb987f7f4cc2873a65c58278c70L8-R19))
*  Add Foo type and "lol" RPC method for testing JsonSerializationError handling in StartWithSetup module ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-68fe8350fe78602fb8fe7b610e6b7d0ad0314bb987f7f4cc2873a65c58278c70L22-R31), [link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-68fe8350fe78602fb8fe7b610e6b7d0ad0314bb987f7f4cc2873a65c58278c70L33-R46))
*  Add test case for JsonSerializationError handling in tests value in StartWithSetup module ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-68fe8350fe78602fb8fe7b610e6b7d0ad0314bb987f7f4cc2873a65c58278c70L33-R46))
*  Reformat test case for multiple start ups in tests value in StartWithSetup module ([link](https://github.com/ionide/LanguageServerProtocol/pull/55/files?diff=unified&w=0#diff-68fe8350fe78602fb8fe7b610e6b7d0ad0314bb987f7f4cc2873a65c58278c70L51-R104))
