### PR TITLE
Add default for WorkspaceSymbolResolve

### DIFF
--- a/src/Server.fs
+++ b/src/Server.fs
@@ -684,6 +684,8 @@ type LspServer() =
   /// The request is sent from the client to the server to resolve additional information for a given workspace symbol.
   abstract member WorkspaceSymbolResolve: WorkspaceSymbol -> AsyncLspResult<WorkspaceSymbol>
 
+  default __.WorkspaceSymbolResolve _ = notImplemented
+
   /// The `workspace/executeCommand` request is sent from the client to the server to trigger command execution
   /// on the server. In most cases the server creates a `WorkspaceEdit` structure and applies the changes to the
   /// workspace using the request `workspace/applyEdit` which is sent from the server to the client.


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f8cc12</samp>

Update `LspServer` type to implement `WorkspaceSymbolResolve` method. This method is part of the Language Server Protocol and allows clients to request more details about workspace symbols.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3f8cc12</samp>

> _`LspServer` grows_
> _Adding `WorkspaceSymbolResolve`_
> _Fall leaves not implemented_

<!--
copilot:emoji
-->

🔎🚧📄

<!--
1.  🔎 - This emoji represents the concept of searching or finding symbols, which is the main purpose of the `WorkspaceSymbol` and `WorkspaceSymbolResolve` methods. It also suggests that the change adds more functionality to the server's symbol capabilities.
2.  🚧 - This emoji represents the concept of construction or work in progress, which is the case for the `LspServer` type as it is being updated to match the latest protocol version. It also suggests that the change is not complete or fully functional, as the default implementation of the `WorkspaceSymbolResolve` method returns an error.
3.  📄 - This emoji represents the concept of documents or files, which are the main units of work for the Language Server Protocol. It also suggests that the change affects the server's ability to handle different kinds of documents or symbols in the workspace.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f8cc12</samp>

*  Add default implementation of `WorkspaceSymbolResolve` method to `LspServer` type ([link](https://github.com/ionide/LanguageServerProtocol/pull/56/files?diff=unified&w=0#diff-df8678e6cac8668fea4f7eb463d4af151e9dc39283d2ed993751075b43d47cc0R686-R687))