### PR TITLE
Update StreamJsonRpc to 2.16.36

### DIFF
--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -32,6 +32,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <!-- Explicitly pinning our FSharp.Core to 6.0.0 so that consumers can use _any_ 6.x version. -->
     <PackageReference Update="FSharp.Core" Version="6.0.0" />
-    <PackageReference Include="StreamJsonRpc" Version="2.10.44" />
+    <PackageReference Include="StreamJsonRpc" Version="2.16.36" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30f3b7d</samp>

Updated `StreamJsonRpc` package to fix a cancellation bug in the language server protocol. The bug affected the `src/Ionide.LanguageServerProtocol.fsproj` file and was reported in issue #25.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 30f3b7d</samp>

> _`StreamJsonRpc` fixed_
> _Cancellation bug in winter_
> _Issue closed, tested_

<!--
copilot:emoji
-->

🐛⬆️🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It can be used to indicate that the change resolved an issue or improved the functionality or reliability of the code.
2.  ⬆️ - This emoji represents an upgrade, which is the secondary effect of the change. It can be used to indicate that the change updated a dependency or increased the compatibility or performance of the code.
3.  🚀 - This emoji represents a launch, which is the final outcome of the change. It can be used to indicate that the change deployed a new feature or enhancement or improved the user experience or satisfaction of the code.
-->

### WHY
Quite a bit has changed https://github.com/microsoft/vs-streamjsonrpc/compare/v2.10.44...v2.16.36

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30f3b7d</samp>

* Update the StreamJsonRpc package version to fix a cancellation bug ([link](https://github.com/ionide/LanguageServerProtocol/pull/57/files?diff=unified&w=0#diff-a1d6bbb3c09a4b955850ed318d6b104fe29a177b21f5aa9153eadbce58124cc1L35-L34))
