### PR TITLE
bump to 8.0 SDK, add in some missing Obsolete members for types that are deprecated in the spec, and fill in some xmldocs.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "fantomas": {
-      "version": "6.2.2",
+      "version": "6.2.3",
       "commands": [
         "fantomas"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,17 +12,17 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v2
+      - uses: actions/checkout@v4
         with:
-          global-json-file: global.json
+            show-progress: false
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
       - name: Run build
         run: dotnet build -c Release src
       - name: Run tests
         run: dotnet test --logger GitHubActions
       - name: Run publish
-        run: dotnet pack -c Release -o release src
+        run: dotnet pack -o release src
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
           prerelease: false
 
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: release/*.nupkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.22] - 15.01.2024
+
+### Added
+* [New Error Code members to match spec-provided error codes in 3.17.0]()
+
+### Changed
+* [Added obsoletion messages to members marked deprecated in the spec]()
+
 ## [0.4.21] - 29.10.2023
 
 ### Fixed

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.200",
-    "rollForward": "latestMinor"
+    "version": "8.0.100",
+    "rollForward": "major"
   }
 }

--- a/src/JsonRpc.fs
+++ b/src/JsonRpc.fs
@@ -43,14 +43,67 @@ type Notification =
     { Version = "2.0"; Method = method'; Params = rpcParams }
 
 module ErrorCodes =
+  open System
   let parseError = -32700
   let invalidRequest = -32600
   let methodNotFound = -32601
   let invalidParams = -32602
   let internalError = -32603
-  let serverErrorStart = -32000
-  let serverErrorEnd = -32099
+
+
+  ///<summary>This is the start range of JSON-RPC reserved error codes.
+  ///It doesn't denote a real error code. No LSP error codes should
+  ///be defined between the start and end range. For backwards
+  ///compatibility the <see cref="ServerNotInitialized"/> and the <see cref="UnknownErrorCode" />
+  ///are left in the range.</summary>
+  let jsonrpcReservedErrorRangeStart = -32099
+
+  [<Obsolete("Use jsonRpcReservedErrorRangeStart instead")>]
+  let serverErrorStart = jsonrpcReservedErrorRangeStart
+
+  /// Error code indicating that a server received a notification or
+  /// request before the server has received the `initialize` request.
+  let serverNotInitialized = -32002
+
+  ///This is the end range of JSON-RPC reserved error codes. It doesn't denote a real error code.
+  let jsonrpcReservedErrorRangeEnd = -32000
+
+  [<Obsolete("Use jsonRpcReservedErrorRangeEnd instead")>]
+  let serverErrorEnd = jsonrpcReservedErrorRangeEnd
+
+
+  /// This is the start range of LSP reserved error codes. It doesn't denote a real error code.
+  let lspReservedErrorRangeStart = -32899
+
+  /// A request failed but it was syntactically correct, e.g the
+  /// method name was known and the parameters were valid. The error
+  /// message should contain human readable information about why
+  /// the request failed.
+  /// @since 3.17.0
+  let RequestFailed = -32803
+
+
+  /// The server cancelled the request. This error code should
+  /// only be used for requests that explicitly support being
+  /// server cancellable.
+  ///
+  /// @since 3.17.0
+  let serverCancelled = -32802
+
+  /// The server detected that the content of a document got
+  /// modified outside normal conditions. A server should
+  /// NOT send this error code if it detects a content change
+  /// in it unprocessed messages. The result even computed
+  /// on an older state might still be useful for the client.
+  ///
+  /// If a client decides that a result is not of any use anymore
+  /// the client should cancel the request.
+  let contentModified = -32801
+
+  /// The client has canceled a request and a server has detected the cancel.
   let requestCancelled = -32800
+  /// This is the end range of LSP reserved error codes. It doesn't denote a real error code.
+  let lspReservedErrorRangeEnd = -32899
 
 type Error =
   { Code: int

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -69,6 +69,7 @@ type DocumentSelector = DocumentFilter[]
 
 /// Position in a text document expressed as zero-based line and zero-based character offset.
 /// A position is between two characters like an ‘insert’ cursor in a editor.
+/// Special values like for example -1 to denote the end of a line are not supported.
 [<DebuggerDisplay("{DebuggerDisplay}")>]
 type Position =
   {
@@ -195,6 +196,7 @@ type SymbolTag =
 
 /// Represents information about programming constructs like variables, classes,
 /// interfaces etc.
+[<Obsolete("Use DocumentSymbol or WorkspaceSymbol instead.")>]
 type SymbolInformation =
   {
     /// The name of this symbol.
@@ -1255,6 +1257,7 @@ type TextDocumentClientCapabilities =
     TypeHierarchy: DynamicCapabilities option
 
     /// Capabilities specific to the `textDocument/inlineValue` request.
+    /// @since 3.17.0
     InlineValue: DynamicCapabilities option
 
     /// Capabilities specific to the `textDocument/inlayHint` request.
@@ -1263,6 +1266,7 @@ type TextDocumentClientCapabilities =
     InlayHint: InlayHintClientCapabilities option
 
     /// Capabilities specific to the diagnostic pull model.
+    /// @since 3.17.0
     Diagnostic: DiagnosticCapabilities option
   }
 
@@ -1316,6 +1320,10 @@ type WindowClientCapabilities =
     showDocument: ShowDocumentClientCapabilities option
   }
 
+/// Client capability that signals how the client
+/// handles stale requests (e.g. a request
+/// for which the client will not process the response
+/// anymore since the information is outdated).
 type StaleRequestSupportClientCapabilities =
   {
     /// The client will actively cancel the request.
@@ -1335,6 +1343,8 @@ type RegularExpressionsClientCapabilities =
     Version: string option
   }
 
+/// Client capabilities specific to the used markdown parser.
+/// @since 3.16.0
 type MarkdownClientCapabilities =
   {
     /// The name of the parser.
@@ -1344,20 +1354,30 @@ type MarkdownClientCapabilities =
     Version: string option
 
     /// A list of HTML tags that the client allows / supports in Markdown.
+    /// @since 3.17.0
     AllowedTags: string[] option
   }
+
+/// A type indicating how positions are encoded,
+/// specifically what column offsets mean.
+///
+/// @since 3.17.0
+type PositionEncodingKind = string
 
 type GeneralClientCapabilities =
   {
     /// Client capability that signals how the client handles stale requests
     /// (e.g. a request for which the client will not process the response
     /// anymore since the information is outdated).
+    /// @since 3.17.0
     StaleRequestSupport: StaleRequestSupportClientCapabilities option
 
     /// Client capabilities specific to regular expressions.
+    /// @since 3.16.0
     RegularExpressions: RegularExpressionsClientCapabilities option
 
     /// Client capabilities specific to the client's markdown parser.
+    /// @since 3.16.0
     Markdown: MarkdownClientCapabilities option
 
     /// The position encodings supported by the client. Client and server have
@@ -1371,7 +1391,7 @@ type GeneralClientCapabilities =
     /// Implementation considerations: since the conversion from one encoding
     /// into another requires the content of the file / line the conversion is
     /// best done where the file is read which is usually on the server side.
-    PositionEncodings: string[] option
+    PositionEncodings: PositionEncodingKind[] option
   }
 
 type ClientCapabilities =
@@ -1386,7 +1406,7 @@ type ClientCapabilities =
     General: GeneralClientCapabilities option
 
     /// Experimental client capabilities.
-    Experimental: JToken option
+    Experimental: LSPAny option
 
     /// Window specific client capabilities.
     Window: WindowClientCapabilities option
@@ -1713,6 +1733,20 @@ type WorkspaceSymbolOptions =
     ResolveProvider: bool option
   }
 
+/// A set of predefined position encoding kinds.
+/// @since 3.17.0
+module PositionEncodingKind =
+  /// Character offsets count UTF-8 code units (e.g bytes).
+  let UTF8 = "utf-8"
+  /// Character offsets count UTF-16 code units. This is the default and must always be supported by servers.
+  let UTF16 = "utf-16"
+  /// Character offsets count UTF-32 code units.
+  ///
+  /// Implementation note: these are the same as Unicode code points,
+  /// so this `PositionEncodingKind` may also be used for an
+  /// encoding-agnostic representation of character offsets.
+  let UTF32 = "utf-32"
+
 type ServerCapabilities =
   {
     /// The position encoding the server picked from the encodings offered by
@@ -1720,7 +1754,7 @@ type ServerCapabilities =
     /// If the client didn't provide any position encodings the only valid value
     /// that a server can return is 'utf-16'.
     /// If omitted it defaults to 'utf-16'.
-    PositionEncoding: string option
+    PositionEncoding: PositionEncodingKind option
 
     /// Defines how text documents are synced. Is either a detailed structure defining each notification or
     /// for backwards compatibility the TextDocumentSyncKind number.
@@ -2279,8 +2313,25 @@ type MarkupContent =
 
 type MarkedStringData = { Language: string; Value: string }
 
+/// <summary>
+/// MarkedString can be used to render human readable text. It is either a
+/// markdown string or a code-block that provides a language and a code snippet.
+/// The language identifier is semantically equal to the optional language
+/// identifier in fenced code blocks in GitHub issues.
+///
+/// The pair of a language and a value is an equivalent to markdown:
+/// <code>
+/// ```${language}
+/// ${value}
+/// ```
+/// </code>
+///
+/// Note that markdown strings will be sanitized - that means html will be
+/// escaped.
+/// </summary>
 [<ErasedUnion>]
 [<RequireQualifiedAccess>]
+[<Obsolete("Use MarkupContent instead")>]
 type MarkedString =
   | String of string
   | WithLanguage of MarkedStringData
@@ -2336,6 +2387,7 @@ type TextDocumentContentChangeEvent =
     Range: Range option
 
     /// The length of the range that got replaced.
+    [<Obsolete("Use Range instead")>]
     RangeLength: int option
 
     /// The new text of the range/document.

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -207,7 +207,7 @@ type SymbolInformation =
     Tags: SymbolTag[] option
 
     /// Indicates if this symbol is deprecated.
-    /// @deprecated Use tags instead
+    [<Obsolete("Use Tags instead")>]
     Deprecated: bool option
 
     /// The location of this symbol. The location's range is used by a tool
@@ -245,7 +245,7 @@ type DocumentSymbol =
     /// tags for this document symbol.
     Tags: SymbolTag[] option
     /// Indicates if this symbol is deprecated.
-    /// @deprecated Use tags instead
+    [<Obsolete("Use Tags instead")>]
     Deprecated: bool option
     /// The range enclosing this symbol not including leading/trailing whitespace
     /// but everything else like comments. This information is typically used to
@@ -1141,7 +1141,7 @@ type RenameClientCapabilities =
     DynamicRegistration: bool option
 
     /// Client supports testing for validity of rename operations before execution.
-    /// @since version 3.12.0
+    /// @since 3.12.0
     PrepareSupport: bool option
 
     /// Client supports the default behavior result
@@ -1420,11 +1420,11 @@ type InitializeParams =
     /// https://en.wikipedia.org/wiki/IETF_language_tag)
     Locale: string option
     /// The rootPath of the workspace. Is null if no folder is open.
-    /// @deprecated in favour of `rootUri`.
+    [<Obsolete("Use RootUri instead")>]
     RootPath: string option
     /// The rootUri of the workspace. Is null if no folder is open. If both
     /// `rootPath` and `rootUri` are set `rootUri` wins.
-    /// @deprecated in favour of `workspaceFolders`
+    [<Obsolete("Use WorkspaceFolders instead")>]
     RootUri: string option
     /// User provided initialization options.
     InitializationOptions: JToken option
@@ -2107,10 +2107,8 @@ type TextDocumentSaveReason =
   /// Manually triggered, e.g. by the user pressing save, by starting debugging,
   /// or by an API call.
   | Manual = 1
-
   /// Automatic after a delay.
   | AfterDelay = 2
-
   /// When the editor lost focus.
   | FocusOut = 3
 
@@ -2449,14 +2447,14 @@ type Command =
 
 type CompletionItemLabelDetails =
   {
-    /// An optional string which is rendered less prominently directly after
-    /// {@link CompletionItem.label label}, without any spacing. Should be used
-    /// for function signatures or type annotations.
+    /// <summary>An optional string which is rendered less prominently directly after
+    ///  <see cref="CompletionItem.Label">label</see>, without any spacing. Should be used
+    /// for function signatures or type annotations.</summary>
     Detail: string option
 
-    /// An optional string which is rendered less prominently after
-    /// {@link CompletionItemLabelDetails.detail}. Should be used for fully
-    /// qualified names or file path.
+    /// <summary>An optional string which is rendered less prominently after
+    /// <see cref="CompletionItemLabelDetails.Detail" />. Should be used for fully
+    /// qualified names or file path.</summary>
     Description: string option
   }
 
@@ -2516,7 +2514,7 @@ type CompletionItem =
     Documentation: Documentation option
 
     /// Indicates if this item is deprecated.
-    /// @deprecated Use `tags` instead if supported.
+    [<Obsolete("Use Tags instead if supported")>]
     Deprecated: bool option
 
     /// Select this item when showing.
@@ -2542,8 +2540,8 @@ type CompletionItem =
     /// and a completion item with an `insertText` of `console` is provided it
     /// will only insert `sole`. Therefore it is recommended to use `textEdit` instead
     /// since it avoids additional client side interpretation.
-    ///
-    /// @deprecated Use textEdit instead.
+
+    [<Obsolete("Use TextEdit instead")>]
     InsertText: string option
 
     /// The format of the insert text. The format applies to both the `insertText` property
@@ -3014,10 +3012,8 @@ type GotoResult =
 type DocumentHighlightKind =
   /// A textual occurrence.
   | Text = 1
-
   /// Read-access of a symbol, like reading a variable.
   | Read = 2
-
   /// Write-access of a symbol, like writing to a variable.
   | Write = 3
 
@@ -3693,6 +3689,7 @@ module MonikerKind =
   let Import = "import"
   /// The moniker represents a symbol that is exported from a project
   let Export = "export"
+
   /// The moniker represents a symbol that is local to a project (e.g. a local
   /// variable of a function, a class not visible outside the project, ...)
   let Local = "local"


### PR DESCRIPTION
Just a few enhancements here - mainly adding `Obsolete` annotations to members so I can ensure that FSAC isn't using RootPath/RootUri anymore.
