### PR TITLE
Fix type definition for GlobPattern

### DIFF
--- a/src/Types.fs
+++ b/src/Types.fs
@@ -2423,9 +2423,7 @@ type RelativePattern =
     Pattern: string
   }
 
-type GlobPattern =
-  | RelativePattern of RelativePattern
-  | Pattern of string
+type GlobPattern = U2<string, RelativePattern>
 
 type FileSystemWatcher =
   {


### PR DESCRIPTION
### WHAT
This fixes type definition for `GlobPattern` data type as defined in LSP spec v3.17:
- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#globPattern

### WHY
The current `GlobPattern` definition as encoded in Types.fs necessitates a wrapper/container for `GlobPattern` values whereas `Pattern` it is defined as type alias for `string` on LSP spec:
- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#pattern
