### PR TITLE
Support JsonRpc via web sockets

### DIFF
--- a/src/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol.fs
@@ -113,7 +113,7 @@ module Server =
             JsonRpcError.ErrorDetail(Code = JsonRpcErrorCode.ParseError, Message = ex.Message, Data = data)
           | _ -> ``base``.CreateErrorDetails(request, ex) }
 
-  let private startWithSetupCore<'client when 'client :> Ionide.LanguageServerProtocol.ILspClient>
+  let startWithSetupCore<'client when 'client :> Ionide.LanguageServerProtocol.ILspClient>
     (setupRequestHandlings: 'client -> Map<string, Delegate>)
     (jsonRpcHandler: IJsonRpcMessageHandler)
     (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client)


### PR DESCRIPTION
With this, I was able to write an LSP server that doesn't need a websocket proxy to communicate with an LSP Client running in the browser, e.g. the Monaco editor. For stdin/stdout users, the API stays the same.

So far, it seems to be stable but I want to test it a bit more before flagging this PR as ready...