### PR TITLE
Add usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ Library for implementing Language Server Protocol in F#.
 
 1. dotnet build
 
-## How to use
+## Examples
 
-See [FsharpLspExample](https://github.com/ssmucny/FsharpLspExample) for documentation with a tutorial and simple worked example explaining how to use this project to build a Language server.
+- [ProtoGraph](https://git.samsmucny.com/ssmucny/Flux-SDK/src/branch/master/src/FluxSDK.LanguageServer/ProtoGraph.fs): Language server for ProtoGraph, a dataflow programming language for Resonite's ProtoFlux
+- [Marksman](https://github.com/artempyanykh/marksman/blob/main/Marksman/Program.fs): A language server for markdown documents
+- [FsAutoComplete](https://github.com/ionide/FsAutoComplete/blob/main/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs): The language server for F# itself by Ionide
+
+See [FsharpLspExample](https://git.samsmucny.com/ssmucny/FsharpLspExample/src/branch/main) ([GitHub mirror](https://github.com/ssmucny/FsharpLspExample)) for documentation with a tutorial and simple worked example explaining how to use this project to build a Language server.
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Library for implementing Language Server Protocol in F#.
 
 1. dotnet build
 
+## How to use
+
+See [FsharpLspExample](https://github.com/ssmucny/FsharpLspExample) for documentation with a tutorial and simple worked example explaining how to use this project to build a Language server.
+
 ## How to contribute
 
 _Imposter syndrome disclaimer_: I want your help. No really, I do.


### PR DESCRIPTION
Added a link to a the separate repository I wrote with a worked example using the library. The repository is synced to Github from my personal Forgejo so that it is all on the same platform. This addresses #68 

I'd like some feedback if this is a reasonable way to add to the docs. Some possible alternatives:
- Inline the documentation (long README)
- Add a docs/example directory in this repository and nest my example in there
- Fork my example to keep a copy under the control of the ionide account and link to that instead
- Probably other options

I'll also take any feedback on fixes or other things that I may have missed in the example.