### PR TITLE
Convert meta model generator to STJ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           global-json-file: global.json
           dotnet-version: |
             8.x
-            9.x
+            10.x
       - name: Run build
         run: dotnet build -c Release src
       - name: Run tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
           global-json-file: global.json
           dotnet-version: |
             8.x
-            9.x
+            10.x
 
       - name: Restore tools
         run: dotnet tool restore

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/ClientServer.cg.fs
+++ b/src/ClientServer.cg.fs
@@ -111,13 +111,11 @@ type ILspServer =
   /// response is of type {@link FoldingRangeList} or a Thenable
   /// that resolves to such.
   abstract TextDocumentFoldingRange: FoldingRangeParams -> AsyncLspResult<option<array<FoldingRange>>>
-
   /// A request to resolve the type definition locations of a symbol at a given text
   /// document position. The request's parameter is of type {@link TextDocumentPositionParams}
   /// the response is of type {@link Declaration} or a typed array of {@link DeclarationLink}
   /// or a Thenable that resolves to such.
   abstract TextDocumentDeclaration: DeclarationParams -> AsyncLspResult<option<U2<Declaration, array<DeclarationLink>>>>
-
   /// A request to provide selection ranges in a document. The request's
   /// parameter is of type {@link SelectionRangeParams}, the
   /// response is of type {@link SelectionRange SelectionRange[]} or a Thenable
@@ -239,7 +237,6 @@ type ILspServer =
   /// server constantly fails on this request. This is done to keep the save fast and
   /// reliable.
   abstract TextDocumentWillSaveWaitUntil: WillSaveTextDocumentParams -> AsyncLspResult<option<array<TextEdit>>>
-
   /// Request to request completion at a given text document position. The request's
   /// parameter is of type {@link TextDocumentPosition} the response
   /// is of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}
@@ -250,7 +247,6 @@ type ILspServer =
   /// request. However, properties that are needed for the initial sorting and filtering, like `sortText`,
   /// `filterText`, `insertText`, and `textEdit`, must not be changed during resolve.
   abstract TextDocumentCompletion: CompletionParams -> AsyncLspResult<option<U2<array<CompletionItem>, CompletionList>>>
-
   /// Request to resolve additional information for a given completion item.The request's
   /// parameter is of type {@link CompletionItem} the response
   /// is of type {@link CompletionItem} or a Thenable that resolves to such.

--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -72,10 +72,10 @@
           so if you happen to read some content during a Restore, that content won't be re-read during a
           subsequent Build  
       -->
-    <MSBuild Projects="@(_GeneratorProject)" Targets="Restore">
+    <MSBuild Projects="@(_GeneratorProject)" Targets="Restore" RemoveProperties="TargetFramework">
       <Output TaskParameter="TargetOutputs" ItemName="_GeneratorApp" />
     </MSBuild>
-    <MSBuild Projects="@(_GeneratorProject)" Targets="Build">
+    <MSBuild Projects="@(_GeneratorProject)" Targets="Build" RemoveProperties="TargetFramework">
       <Output TaskParameter="TargetOutputs" ItemName="_GeneratorApp" />
     </MSBuild>
 

--- a/src/Types.cg.fs
+++ b/src/Types.cg.fs
@@ -5,7 +5,6 @@ open System.Runtime.Serialization
 open System.Diagnostics
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
-
 /// URI's are transferred as strings. The URI's format is defined in https://tools.ietf.org/html/rfc3986
 ///
 /// See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri
@@ -1635,7 +1634,6 @@ type WorkspaceDiagnosticParams = {
 ///
 /// @since 3.17.0
 type WorkspaceDiagnosticReport = { Items: WorkspaceDocumentDiagnosticReport[] }
-
 /// A partial result for a workspace diagnostic report.
 ///
 /// @since 3.17.0
@@ -3326,7 +3324,6 @@ type WorkDoneProgressEnd = {
 }
 
 type SetTraceParams = { Value: TraceValues }
-
 type LogTraceParams = { Message: string; Verbose: string option }
 
 type CancelParams = {
@@ -4485,8 +4482,7 @@ type Diagnostic = {
 
   [<DebuggerBrowsable(DebuggerBrowsableState.Never); JsonIgnore>]
   member x.DebuggerDisplay =
-    $"[{defaultArg x.Severity DiagnosticSeverity.Error}] ({x.Range.DebuggerDisplay}) {x.Message} ({Option.map string x.Code
-                                                                                                   |> Option.defaultValue String.Empty})"
+    $"[{defaultArg x.Severity DiagnosticSeverity.Error}] ({x.Range.DebuggerDisplay}) {x.Message} ({Option.map string x.Code |> Option.defaultValue String.Empty})"
 
 /// Contains additional information about the context in which a completion request is triggered.
 type CompletionContext = {

--- a/tests/Ionide.LanguageServerProtocol.Tests.fsproj
+++ b/tests/Ionide.LanguageServerProtocol.Tests.fsproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 

--- a/tools/MetaModelGenerator/Common.fs
+++ b/tools/MetaModelGenerator/Common.fs
@@ -1,5 +1,22 @@
 namespace MetaModelGenerator
 
+module Formatting =
+  open Fantomas.Core
+
+  let formatConfig = {
+    FormatConfig.Default with
+        IndentSize = 2
+        MaxRecordWidth = 80
+        MaxValueBindingWidth = 120
+        MaxFunctionBindingWidth = 120
+        MaxDotGetExpressionWidth = 120
+        MaxInfixOperatorExpression = 10
+        ArrayOrListMultilineFormatter = MultilineFormatterType.NumberOfItems
+        MultilineBracketStyle = MultilineBracketStyle.Stroustrup
+        MultiLineLambdaClosingNewline = true
+        InsertFinalNewline = false
+  }
+
 
 module FileWriters =
   open System.IO

--- a/tools/MetaModelGenerator/GenerateClientServer.fs
+++ b/tools/MetaModelGenerator/GenerateClientServer.fs
@@ -8,19 +8,7 @@ module GenerateClientServer =
   open Fantomas.Core
 
 
-  let private formatConfig = {
-    FormatConfig.Default with
-        IndentSize = 2
-        MaxRecordWidth = 80
-        MaxValueBindingWidth = 120
-        MaxFunctionBindingWidth = 120
-        MaxDotGetExpressionWidth = 120
-        MaxInfixOperatorExpression = 10
-        ArrayOrListMultilineFormatter = MultilineFormatterType.NumberOfItems
-        MultilineBracketStyle = MultilineBracketStyle.Stroustrup
-        MultiLineLambdaClosingNewline = true
-        InsertFinalNewline = false
-  }
+  let private formatConfig = Formatting.formatConfig
 
   let generateClientServer (parsedMetaModel: MetaModel.MetaModel) outputPath =
     async {

--- a/tools/MetaModelGenerator/GenerateClientServer.fs
+++ b/tools/MetaModelGenerator/GenerateClientServer.fs
@@ -8,6 +8,20 @@ module GenerateClientServer =
   open Fantomas.Core
 
 
+  let private formatConfig = {
+    FormatConfig.Default with
+        IndentSize = 2
+        MaxRecordWidth = 80
+        MaxValueBindingWidth = 120
+        MaxFunctionBindingWidth = 120
+        MaxDotGetExpressionWidth = 120
+        MaxInfixOperatorExpression = 10
+        ArrayOrListMultilineFormatter = MultilineFormatterType.NumberOfItems
+        MultilineBracketStyle = MultilineBracketStyle.Stroustrup
+        MultiLineLambdaClosingNewline = true
+        InsertFinalNewline = false
+  }
+
   let generateClientServer (parsedMetaModel: MetaModel.MetaModel) outputPath =
     async {
       printfn "Generating generateClientServer"
@@ -312,7 +326,7 @@ module GenerateClientServer =
       let! formattedText =
         oak
         |> Gen.mkOak
-        |> CodeFormatter.FormatOakAsync
+        |> fun oak -> CodeFormatter.FormatOakAsync(oak, formatConfig)
 
       do! FileWriters.writeIfChanged outputPath formattedText
 

--- a/tools/MetaModelGenerator/GenerateTypes.fs
+++ b/tools/MetaModelGenerator/GenerateTypes.fs
@@ -15,7 +15,7 @@ module GenerateTypes =
   open type Fabulous.AST.Ast
 
   open Fantomas.FCS.Syntax
-  open Newtonsoft.Json.Linq
+
 
   let getIdent (x: IdentifierOrDot list) =
     x
@@ -27,7 +27,7 @@ module GenerateTypes =
     |> String.concat ""
 
 
-  let JToken = LongIdent(nameof JToken)
+  let JToken = LongIdent "JToken"
 
   let createOption (t: WidgetBuilder<Type>) = Ast.OptionPostfix t
 
@@ -866,6 +866,20 @@ module GenerateTypes =
     }
 
 
+  let private formatConfig = {
+    FormatConfig.Default with
+        IndentSize = 2
+        MaxRecordWidth = 80
+        MaxValueBindingWidth = 120
+        MaxFunctionBindingWidth = 120
+        MaxDotGetExpressionWidth = 120
+        MaxInfixOperatorExpression = 10
+        ArrayOrListMultilineFormatter = MultilineFormatterType.NumberOfItems
+        MultilineBracketStyle = MultilineBracketStyle.Stroustrup
+        MultiLineLambdaClosingNewline = true
+        InsertFinalNewline = false
+  }
+
   /// The main entry point to generating types from a metaModel.json file
   let generateType (parsedMetaModel: MetaModel.MetaModel) outputPath =
     async {
@@ -965,7 +979,7 @@ See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17
       let! formattedText =
         oak
         |> Gen.mkOak
-        |> CodeFormatter.FormatOakAsync
+        |> fun oak -> CodeFormatter.FormatOakAsync(oak, formatConfig)
 
       do! FileWriters.writeIfChanged outputPath formattedText
     }

--- a/tools/MetaModelGenerator/GenerateTypes.fs
+++ b/tools/MetaModelGenerator/GenerateTypes.fs
@@ -866,19 +866,7 @@ module GenerateTypes =
     }
 
 
-  let private formatConfig = {
-    FormatConfig.Default with
-        IndentSize = 2
-        MaxRecordWidth = 80
-        MaxValueBindingWidth = 120
-        MaxFunctionBindingWidth = 120
-        MaxDotGetExpressionWidth = 120
-        MaxInfixOperatorExpression = 10
-        ArrayOrListMultilineFormatter = MultilineFormatterType.NumberOfItems
-        MultilineBracketStyle = MultilineBracketStyle.Stroustrup
-        MultiLineLambdaClosingNewline = true
-        InsertFinalNewline = false
-  }
+  let private formatConfig = Formatting.formatConfig
 
   /// The main entry point to generating types from a metaModel.json file
   let generateType (parsedMetaModel: MetaModel.MetaModel) outputPath =

--- a/tools/MetaModelGenerator/MetaModel.fs
+++ b/tools/MetaModelGenerator/MetaModel.fs
@@ -420,11 +420,7 @@ module rec MetaModel =
 
       override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, options: JsonSerializerOptions) =
         match reader.TokenType with
-        | JsonTokenType.Null ->
-          reader.Read()
-          |> ignore
-
-          None
+        | JsonTokenType.Null -> None
         | JsonTokenType.StartArray ->
           let arr = JsonSerializer.Deserialize<'T array>(&reader, options)
           Some arr
@@ -490,13 +486,9 @@ module rec MetaModel =
       inherit JsonConverter<'T option>()
 
       override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, options: JsonSerializerOptions) =
-        if reader.TokenType = JsonTokenType.Null then
-          reader.Read()
-          |> ignore
-
-          None
-        else
-          Some(JsonSerializer.Deserialize<'T>(&reader, options))
+        match reader.TokenType with
+        | JsonTokenType.Null -> None
+        | _ -> Some(JsonSerializer.Deserialize<'T>(&reader, options))
 
       override _.Write(writer: Utf8JsonWriter, value: 'T option, options: JsonSerializerOptions) =
         match value with

--- a/tools/MetaModelGenerator/MetaModel.fs
+++ b/tools/MetaModelGenerator/MetaModel.fs
@@ -397,7 +397,7 @@ module rec MetaModel =
       inherit JsonConverter<MapKeyType>()
 
       override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, options: JsonSerializerOptions) =
-        let doc = JsonDocument.ParseValue(&reader)
+        use doc = JsonDocument.ParseValue(&reader)
         let root = doc.RootElement
         let kind = root.GetProperty("kind").GetString()
 
@@ -439,7 +439,7 @@ module rec MetaModel =
       inherit JsonConverter<Type>()
 
       override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, options: JsonSerializerOptions) =
-        let doc = JsonDocument.ParseValue(&reader)
+        use doc = JsonDocument.ParseValue(&reader)
         let root = doc.RootElement
         let kind = root.GetProperty("kind").GetString()
         // Helper: re-serialise a sub-element and deserialize as 'T

--- a/tools/MetaModelGenerator/MetaModel.fs
+++ b/tools/MetaModelGenerator/MetaModel.fs
@@ -18,36 +18,15 @@ module Proposed =
     else
       true
 
-module Preconverts =
-  open Newtonsoft.Json
-  open Newtonsoft.Json.Linq
-
-  type SingleOrArrayConverter<'T>() =
-    inherit JsonConverter()
-
-    override x.CanConvert(tobject: System.Type) = tobject = typeof<'T array>
-
-    override _.WriteJson(writer: JsonWriter, value, serializer: JsonSerializer) : unit =
-      failwith "Should never be writing this structure, it comes from Microsoft LSP Spec"
-
-    override _.ReadJson(reader: JsonReader, objectType: System.Type, existingValue: obj, serializer: JsonSerializer) =
-      let token = JToken.Load reader
-
-      match token.Type with
-      | JTokenType.Array -> serializer.Deserialize(reader, objectType)
-      | JTokenType.Null -> null
-      | _ -> Some [| token.ToObject<'T>(serializer) |]
-
 module rec MetaModel =
   open System
-  open Newtonsoft.Json.Linq
-  open Newtonsoft.Json
-  open Ionide.LanguageServerProtocol
+  open System.Text.Json
+  open System.Text.Json.Serialization
 
   type MetaData = { Version: string }
 
   /// Indicates in which direction a message is sent in the protocol.
-  [<JsonConverter(typeof<Newtonsoft.Json.Converters.StringEnumConverter>)>]
+  [<JsonConverter(typeof<JsonStringEnumConverter>)>]
   type MessageDirection =
     | ClientToServer = 0
     | ServerToClient = 1
@@ -66,7 +45,6 @@ module rec MetaModel =
     /// The request's method name.
     Method: string
     /// The parameter type(s) if any.
-    [<JsonConverter(typeof<Preconverts.SingleOrArrayConverter<Type>>)>]
     Params: Type array option
     /// Optional partial result type if the request supports partial result reporting.
     PartialResult: Type option
@@ -102,7 +80,6 @@ module rec MetaModel =
     /// The request's method name.
     Method: string
     /// The parameter type(s) if any.
-    [<JsonConverter(typeof<Preconverts.SingleOrArrayConverter<Type>>)>]
     Params: Type array option
     /// Whether this is a proposed feature. If omitted the notification is final.",
     Proposed: bool option
@@ -334,7 +311,7 @@ module rec MetaModel =
       x.Documentation
       |> Option.map StructuredDocs.parse
 
-  [<JsonConverter(typeof<Newtonsoft.Json.Converters.StringEnumConverter>)>]
+  [<JsonConverter(typeof<JsonStringEnumConverter>)>]
   type EnumerationTypeNameValues =
     | String = 0
     | Integer = 1
@@ -349,6 +326,7 @@ module rec MetaModel =
     Name: string
     Proposed: bool option
     Since: string option
+    [<JsonConverter(typeof<Converters.StringOrNumberAsStringConverter>)>]
     Value: string
   } with
 
@@ -398,88 +376,168 @@ module rec MetaModel =
 
   module Converters =
 
+    /// Reads a JSON value that is either a JSON string or a JSON number, returning it as a string.
+    /// This is needed because integer/uinteger enumeration values are serialised as numbers in metaModel.json.
+    type StringOrNumberAsStringConverter() =
+      inherit JsonConverter<string>()
+
+      override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, _options: JsonSerializerOptions) =
+        match reader.TokenType with
+        | JsonTokenType.String -> reader.GetString()
+        | JsonTokenType.Number ->
+          // Preserve the raw number token as a string (e.g. "-32700")
+          reader.GetInt64()
+          |> string
+        | other -> failwithf "StringOrNumberAsStringConverter: unexpected token %A" other
+
+      override _.Write(writer: Utf8JsonWriter, value: string, _options: JsonSerializerOptions) =
+        writer.WriteStringValue(value)
+
     type MapKeyTypeConverter() =
       inherit JsonConverter<MapKeyType>()
 
-      override _.WriteJson(writer: JsonWriter, value: MapKeyType, serializer: JsonSerializer) : unit =
-        failwith "Should never be writing this structure, it comes from Microsoft LSP Spec"
-
-      override _.ReadJson
-        (
-          reader: JsonReader,
-          objectType: System.Type,
-          existingValue: MapKeyType,
-          hasExistingValue,
-          serializer: JsonSerializer
-        ) =
-        let jobj = JObject.Load(reader)
-        let kind = jobj.["kind"].Value<string>()
+      override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, options: JsonSerializerOptions) =
+        let doc = JsonDocument.ParseValue(&reader)
+        let root = doc.RootElement
+        let kind = root.GetProperty("kind").GetString()
 
         match kind with
         | ReferenceTypeConst ->
-          let name = jobj.["name"].Value<string>()
+          let name = root.GetProperty("name").GetString()
           MapKeyType.ReferenceType { Kind = kind; Name = name }
         | "base" ->
-          let name = jobj.["name"].Value<string>()
+          let name = root.GetProperty("name").GetString()
           MapKeyType.Base {| Kind = kind; Name = MapKeyNameEnum.Parse name |}
         | _ -> failwithf "Unknown map key type: %s" kind
+
+      override _.Write(_writer, _value, _options) =
+        failwith "Should never be writing this structure, it comes from Microsoft LSP Spec"
+
+    /// Reads a value that may be either a single item or an array of items,
+    /// deserializing it as 'T array option (None when the JSON token is null).
+    type SingleOrArrayConverter<'T>() =
+      inherit JsonConverter<'T array option>()
+
+      override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, options: JsonSerializerOptions) =
+        match reader.TokenType with
+        | JsonTokenType.Null ->
+          reader.Read()
+          |> ignore
+
+          None
+        | JsonTokenType.StartArray ->
+          let arr = JsonSerializer.Deserialize<'T array>(&reader, options)
+          Some arr
+        | _ ->
+          let item = JsonSerializer.Deserialize<'T>(&reader, options)
+          Some [| item |]
+
+      override _.Write(_writer, _value, _options) =
+        failwith "Should never be writing this structure, it comes from Microsoft LSP Spec"
 
     type TypeConverter() =
       inherit JsonConverter<Type>()
 
-      override _.WriteJson(writer: JsonWriter, value: MetaModel.Type, serializer: JsonSerializer) : unit =
-        failwith "Should never be writing this structure, it comes from Microsoft LSP Spec"
-
-      override _.ReadJson
-        (reader: JsonReader, objectType: System.Type, existingValue: Type, hasExistingValue, serializer: JsonSerializer)
-        =
-        let jobj = JObject.Load(reader)
-        let kind = jobj.["kind"].Value<string>()
+      override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, options: JsonSerializerOptions) =
+        let doc = JsonDocument.ParseValue(&reader)
+        let root = doc.RootElement
+        let kind = root.GetProperty("kind").GetString()
+        // Helper: re-serialise a sub-element and deserialize as 'T
+        let deser (t: System.Type) (el: JsonElement) = JsonSerializer.Deserialize(el.GetRawText(), t, options)
 
         match kind with
         | BaseTypeConst ->
-          let name = jobj.["name"].Value<string>()
+          let name = root.GetProperty("name").GetString()
           Type.BaseType { Kind = kind; Name = BaseTypes.Parse name }
         | ReferenceTypeConst ->
-          let name = jobj.["name"].Value<string>()
+          let name = root.GetProperty("name").GetString()
           Type.ReferenceType { Kind = kind; Name = name }
         | ArrayTypeConst ->
-          let element = jobj.["element"].ToObject<Type>(serializer)
+          let element = deser typeof<Type> (root.GetProperty("element")) :?> Type
           Type.ArrayType { Kind = kind; Element = element }
         | MapTypeConst ->
-          let key = jobj.["key"].ToObject<MapKeyType>(serializer)
-          let value = jobj.["value"].ToObject<Type>(serializer)
+          let key = deser typeof<MapKeyType> (root.GetProperty("key")) :?> MapKeyType
+          let value = deser typeof<Type> (root.GetProperty("value")) :?> Type
           Type.MapType { Kind = kind; Key = key; Value = value }
         | AndTypeConst ->
-          let items = jobj.["items"].ToObject<Type[]>(serializer)
+          let items = deser typeof<Type[]> (root.GetProperty("items")) :?> Type[]
           Type.AndType { Kind = kind; Items = items }
         | OrTypeConst ->
-          let items = jobj.["items"].ToObject<Type[]>(serializer)
+          let items = deser typeof<Type[]> (root.GetProperty("items")) :?> Type[]
           Type.OrType { Kind = kind; Items = items }
         | TupleTypeConst ->
-          let items = jobj.["items"].ToObject<Type[]>(serializer)
+          let items = deser typeof<Type[]> (root.GetProperty("items")) :?> Type[]
           Type.TupleType { Kind = kind; Items = items }
         | StructureTypeLiteral ->
-          let value = jobj.["value"].ToObject<StructureLiteral>(serializer)
+          let value = deser typeof<StructureLiteral> (root.GetProperty("value")) :?> StructureLiteral
           Type.StructureLiteralType { Kind = kind; Value = value }
         | StringLiteralTypeConst ->
-          let value = jobj.["value"].Value<string>()
+          let value = root.GetProperty("value").GetString()
           Type.StringLiteralType { Kind = kind; Value = value }
         | IntegerLiteralTypeConst ->
-          let value = jobj.["value"].Value<decimal>()
+          let value = root.GetProperty("value").GetDecimal()
           Type.IntegerLiteralType { Kind = kind; Value = value }
         | BooleanLiteralTypeConst ->
-          let value = jobj.["value"].Value<bool>()
+          let value = root.GetProperty("value").GetBoolean()
           Type.BooleanLiteralType { Kind = kind; Value = value }
         | _ -> failwithf "Unknown type kind: %s" kind
 
+      override _.Write(_writer, _value, _options) =
+        failwith "Should never be writing this structure, it comes from Microsoft LSP Spec"
 
-  let metaModelSerializerSettings =
-    let settings = JsonSerializerSettings()
-    settings.Converters.Add(Converters.TypeConverter() :> JsonConverter)
-    settings.Converters.Add(Converters.MapKeyTypeConverter() :> JsonConverter)
-    settings.Converters.Add(JsonUtils.OptionConverter() :> JsonConverter)
-    settings
+    /// STJ converter for F# option types.
+    type OptionConverter<'T>() =
+      inherit JsonConverter<'T option>()
+
+      override _.Read(reader: byref<Utf8JsonReader>, _typeToConvert: System.Type, options: JsonSerializerOptions) =
+        if reader.TokenType = JsonTokenType.Null then
+          reader.Read()
+          |> ignore
+
+          None
+        else
+          Some(JsonSerializer.Deserialize<'T>(&reader, options))
+
+      override _.Write(writer: Utf8JsonWriter, value: 'T option, options: JsonSerializerOptions) =
+        match value with
+        | None -> writer.WriteNullValue()
+        | Some v -> JsonSerializer.Serialize(writer, v, options)
+
+    type OptionConverterFactory() =
+      inherit JsonConverterFactory()
+
+      override _.CanConvert(t: System.Type) =
+        t.IsGenericType
+        && t.GetGenericTypeDefinition() = typedefof<option<_>>
+
+      override _.CreateConverter(t: System.Type, _options: JsonSerializerOptions) =
+        let innerType = t.GetGenericArguments()[0]
+        let converterType = typedefof<OptionConverter<_>>.MakeGenericType(innerType)
+        System.Activator.CreateInstance(converterType) :?> JsonConverter
+
+    /// STJ converter for 'T array option fields that may be a single item or an array in JSON.
+    type SingleOrArrayConverterFactory() =
+      inherit JsonConverterFactory()
+
+      override _.CanConvert(t: System.Type) =
+        t.IsGenericType
+        && t.GetGenericTypeDefinition() = typedefof<option<_>>
+        && t.GetGenericArguments().[0].IsArray
+
+      override _.CreateConverter(t: System.Type, _options: JsonSerializerOptions) =
+        let elementType = t.GetGenericArguments().[0].GetElementType()
+        let converterType = typedefof<SingleOrArrayConverter<_>>.MakeGenericType([| elementType |])
+        System.Activator.CreateInstance(converterType) :?> JsonConverter
+
+  let metaModelSerializerOptions =
+    let options = JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
+    options.Converters.Add(Converters.TypeConverter())
+    options.Converters.Add(Converters.MapKeyTypeConverter())
+    // SingleOrArrayConverterFactory must come before OptionConverterFactory
+    // so that 'Type array option' fields hit the right converter
+    options.Converters.Add(Converters.SingleOrArrayConverterFactory())
+    options.Converters.Add(Converters.OptionConverterFactory())
+    options
 
   let isNullableType (t: MetaModel.Type) =
     match t with

--- a/tools/MetaModelGenerator/MetaModelGenerator.fsproj
+++ b/tools/MetaModelGenerator/MetaModelGenerator.fsproj
@@ -5,11 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Argu" Version="*" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Fabulous.AST" Version="[1.2.0]" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="../../src/OptionConverter.fs" />
     <Compile Include="PrimitiveExtensions.fs" />
     <Compile Include="MetaModel.fs" />
     <Compile Include="Common.fs" />

--- a/tools/MetaModelGenerator/MetaModelGenerator.fsproj
+++ b/tools/MetaModelGenerator/MetaModelGenerator.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Argu" Version="*" />

--- a/tools/MetaModelGenerator/Program.fs
+++ b/tools/MetaModelGenerator/Program.fs
@@ -3,7 +3,7 @@
 module Main =
   open Argu
   open System
-  open Newtonsoft.Json
+  open System.Text.Json
   open System.IO
 
   type TypeArgs =
@@ -50,7 +50,7 @@ module Main =
       printfn "Deserializing metaModel"
 
       let parsedMetaModel =
-        JsonConvert.DeserializeObject<MetaModel.MetaModel>(metaModel, MetaModel.metaModelSerializerSettings)
+        JsonSerializer.Deserialize<MetaModel.MetaModel>(metaModel, MetaModel.metaModelSerializerOptions)
 
       return parsedMetaModel
     }


### PR DESCRIPTION
## Summary

- Replace `Newtonsoft.Json` with `System.Text.Json` in the `MetaModelGenerator` tool (for parsing `metaModel.json`); generated output still references Newtonsoft.Json unchanged
- Drop the `Newtonsoft.Json` package reference and `../../src/OptionConverter.fs` from the tool project
- Switch `MetaModelGenerator` to `net10.0` and update `global.json` + CI workflows accordingly
- Pass an explicit `FormatConfig` to `FormatOakAsync` matching `.editorconfig`, keeping generated output stable across runs
- Fix `NU1202` during `dotnet pack src` by adding `RemoveProperties="TargetFramework"` to the tool's MSBuild Restore/Build calls, so the tool's own TFM is used instead of inheriting `netstandard2.0` from the outer build

**Notable**: `EnumerationEntry.Value` needs a `StringOrNumberAsStringConverter` because integer enum values in `metaModel.json` are JSON numbers — NSJ coerced them silently, STJ does not.

🤖 Generated with [eca](https://eca.dev)
