### PR TITLE
Add .NET 10 Native AOT support with static protocol metadata

### DIFF
--- a/src/AotJsonRpc.fs
+++ b/src/AotJsonRpc.fs
@@ -1,0 +1,91 @@
+module Ionide.LanguageServerProtocol.JsonRpc
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open Ionide.LanguageServerProtocol.Types
+open StreamJsonRpc
+
+module ErrorCodes =
+  let jsonrpcReservedErrorRangeStart = -32099
+  let jsonrpcReservedErrorRangeEnd = -32000
+  let lspReservedErrorRangeStart = -32899
+  let lspReservedErrorRangeEnd = -32899
+
+type Error = {
+  Code: int
+  Message: string
+  Data: LSPAny option
+} with
+
+  override _.ToString() = "Language server protocol error"
+
+  static member Create(code: int, message: string) = { Code = code; Message = message; Data = None }
+
+  static member ParseError(?message) = Error.Create(int Types.ErrorCodes.ParseError, defaultArg message "Parse error")
+
+  static member InvalidRequest(?message) =
+    Error.Create(int Types.ErrorCodes.InvalidRequest, defaultArg message "Invalid Request")
+
+  static member MethodNotFound(?message) =
+    Error.Create(int Types.ErrorCodes.MethodNotFound, defaultArg message "Method not found")
+
+  static member InvalidParams(?message) =
+    Error.Create(int Types.ErrorCodes.InvalidParams, defaultArg message "Invalid params")
+
+  static member InternalError(?message: string) =
+    Error.Create(int Types.ErrorCodes.InternalError, defaultArg message "Internal error")
+
+  static member RequestCancelled(?message) =
+    Error.Create(int LSPErrorCodes.RequestCancelled, defaultArg message "Request cancelled")
+
+type LspResult<'result> = Result<'result, Error>
+type AsyncLspResult<'result> = Async<LspResult<'result>>
+
+module LspResult =
+  let success x : LspResult<_> = Ok x
+  let invalidParams message : LspResult<_> = Error(Error.InvalidParams message)
+
+  let internalError<'a> (message: string) : LspResult<'a> =
+    Error(Error.Create(int Types.ErrorCodes.InvalidParams, message))
+
+  let notImplemented<'a> : LspResult<'a> = Error(Error.MethodNotFound())
+  let requestCancelled<'a> : LspResult<'a> = Error(Error.RequestCancelled())
+
+module AsyncLspResult =
+  let success x : AsyncLspResult<_> = async.Return(Ok x)
+  let invalidParams message : AsyncLspResult<_> = async.Return(LspResult.invalidParams message)
+  let internalError message : AsyncLspResult<_> = async.Return(LspResult.internalError message)
+  let notImplemented<'a> : AsyncLspResult<'a> = async.Return LspResult.notImplemented
+  let requestCancelled<'a> : AsyncLspResult<'a> = async.Return LspResult.requestCancelled
+
+module Requests =
+  let requestHandling<'param, 'result> (run: 'param -> AsyncLspResult<'result>) : Delegate =
+    let runAsTask param ct =
+      let pending = run param
+
+      async {
+        let! result = pending
+
+        match result with
+        | Ok value -> return value
+        | Error error ->
+          let rpcException = LocalRpcException(error.Message)
+          rpcException.ErrorCode <- error.Code
+
+          rpcException.ErrorData <-
+            error.Data
+            |> Option.map box
+            |> Option.defaultValue null
+
+          return raise rpcException
+      }
+      |> fun operation -> Async.StartAsTask(operation, cancellationToken = ct)
+
+    Func<'param, CancellationToken, Task<'result>>(runAsTask) :> Delegate
+
+  let internal notificationSuccess (response: Async<unit>) =
+    async {
+      do! response
+      return Ok()
+    }

--- a/src/AotJsonRpc.fs
+++ b/src/AotJsonRpc.fs
@@ -18,8 +18,6 @@ type Error = {
   Data: LSPAny option
 } with
 
-  override _.ToString() = "Language server protocol error"
-
   static member Create(code: int, message: string) = { Code = code; Message = message; Data = None }
 
   static member ParseError(?message) = Error.Create(int Types.ErrorCodes.ParseError, defaultArg message "Parse error")

--- a/src/AotLanguageServerProtocol.fs
+++ b/src/AotLanguageServerProtocol.fs
@@ -1,0 +1,138 @@
+namespace Ionide.LanguageServerProtocol
+
+module Server =
+  open System
+  open System.IO
+  open System.Threading
+  open System.Threading.Tasks
+  open Ionide.LanguageServerProtocol.JsonRpc
+  open Ionide.LanguageServerProtocol.Logging
+  open Ionide.LanguageServerProtocol.StaticMetadata
+  open StreamJsonRpc
+  open StreamJsonRpc.Protocol
+
+  type ClientNotificationSender = string -> obj -> AsyncLspResult<unit>
+
+  type ClientRequestSender =
+    abstract member Send<'a> : string -> obj -> AsyncLspResult<'a>
+
+  let logger = LogProvider.getLoggerByName "LSP Server"
+
+  type LspCloseReason =
+    | RequestedByClient = 0
+    | ErrorExitWithoutShutdown = 1
+    | ErrorStreamClosed = 2
+
+  let requestHandling<'param, 'result> (run: 'param -> AsyncLspResult<'result>) = Requests.requestHandling run
+
+  let serverRequestHandling<'server, 'param, 'result when 'server :> ILspServer>
+    (run: 'server -> 'param -> AsyncLspResult<'result>)
+    : Mappings.ServerRequestHandling<'server> =
+    { Run = fun server -> requestHandling (run server) }
+
+  let defaultRequestHandlings () : Map<string, Mappings.ServerRequestHandling<'server>> =
+    Mappings.routeMappings ()
+    |> Map.ofList
+
+  type private StaticProtocolRpc(handler: IJsonRpcMessageHandler) =
+    inherit JsonRpc(handler)
+
+    override _.IsFatalException(exception': Exception) =
+      match exception' with
+      | :? LocalRpcException
+      | :? System.Text.Json.JsonException -> false
+      | _ -> true
+
+    override this.CreateErrorDetails(request, exception') =
+      match exception' with
+      | :? System.Text.Json.JsonException as jsonException ->
+        JsonRpcError.ErrorDetail(Code = JsonRpcErrorCode.ParseError, Message = jsonException.Message)
+      | _ -> base.CreateErrorDetails(request, exception')
+
+  let private run<'client, 'server when 'client :> ILspClient and 'server :> ILspServer>
+    (requestHandlings: Map<string, Mappings.ServerRequestHandling<'server>>)
+    (handler: IJsonRpcMessageHandler)
+    (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client)
+    (serverCreator: 'client -> 'server)
+    =
+    use jsonRpc = new StaticProtocolRpc(handler)
+
+    let sendNotification methodName (value: obj) =
+      async {
+        do!
+          ProtocolMetadata.NotifyAsync(jsonRpc, methodName, ProtocolMetadata.Serialize(value))
+          |> Async.AwaitTask
+
+        return LspResult.success ()
+      }
+
+    let sendRequest methodName (value: obj) =
+      async {
+        let! response =
+          ProtocolMetadata.InvokeAsync(jsonRpc, methodName, ProtocolMetadata.Serialize(value))
+          |> Async.AwaitTask
+
+        return
+          ProtocolMetadata.Deserialize<'response>(response)
+          |> LspResult.success
+      }
+
+    use client =
+      clientCreator (
+        sendNotification,
+        { new ClientRequestSender with
+            member _.Send methodName value = sendRequest methodName value
+        }
+      )
+
+    use server = serverCreator client
+    let mutable shutdownReceived = false
+    let mutable exitReceived = false
+    use exitSemaphore = new SemaphoreSlim(0, 1)
+
+    let target =
+      StaticProtocolTarget(
+        server,
+        requestHandlings,
+        Action(fun () -> shutdownReceived <- true),
+        Action(fun () ->
+          exitReceived <- true
+
+          exitSemaphore.Release()
+          |> ignore
+        )
+      )
+
+    jsonRpc.AddLocalRpcTarget(ProtocolMetadata.Target, target, null)
+    jsonRpc.StartListening()
+    let completed = Task.WaitAny(jsonRpc.Completion, exitSemaphore.WaitAsync())
+
+    if
+      completed = 0
+      && not jsonRpc.Completion.IsCompletedSuccessfully
+    then
+      jsonRpc.Completion.GetAwaiter().GetResult()
+
+    match shutdownReceived, exitReceived with
+    | true, true -> LspCloseReason.RequestedByClient
+    | false, true -> LspCloseReason.ErrorExitWithoutShutdown
+    | _ -> LspCloseReason.ErrorStreamClosed
+
+  let start<'client, 'server when 'client :> ILspClient and 'server :> ILspServer>
+    (requestHandlings: Map<string, Mappings.ServerRequestHandling<'server>>)
+    (input: Stream)
+    (output: Stream)
+    (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client)
+    (serverCreator: 'client -> 'server)
+    =
+    use handler = new HeaderDelimitedMessageHandler(output, input, FormatterFactory.Create())
+    run requestHandlings handler clientCreator serverCreator
+
+  let startWs<'client, 'server when 'client :> ILspClient and 'server :> ILspServer>
+    (requestHandlings: Map<string, Mappings.ServerRequestHandling<'server>>)
+    (socket: Net.WebSockets.WebSocket)
+    (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'client)
+    (serverCreator: 'client -> 'server)
+    =
+    use handler = new WebSocketMessageHandler(socket, FormatterFactory.Create())
+    run requestHandlings handler clientCreator serverCreator

--- a/src/AotRuntime.fs
+++ b/src/AotRuntime.fs
@@ -1,0 +1,88 @@
+namespace Ionide.LanguageServerProtocol
+
+module internal AotRuntime =
+  open System
+  open System.Text.Json
+  open System.Threading
+  open System.Threading.Tasks
+  open Ionide.LanguageServerProtocol.JsonRpc
+  open Ionide.LanguageServerProtocol.StaticMetadata
+  open StreamJsonRpc
+
+  let private findHandling server (handlings: Map<string, Mappings.ServerRequestHandling<'server>>) route =
+    match Map.tryFind route handlings with
+    | Some handling -> handling.Run server
+    | None ->
+      let rpcException = LocalRpcException(String.Concat("Method not found: ", route))
+      rpcException.ErrorCode <- int Types.ErrorCodes.MethodNotFound
+      raise rpcException
+
+  let invokeWithParameter<'server, 'parameter, 'result when 'server :> ILspServer>
+    (server: 'server)
+    (handlings: Map<string, Mappings.ServerRequestHandling<'server>>)
+    route
+    (request: JsonElement)
+    (cancellationToken: CancellationToken)
+    (_infer: 'parameter -> AsyncLspResult<'result>)
+    =
+    task {
+      let handling = findHandling server handlings route :?> Func<'parameter, CancellationToken, Task<'result>>
+      let parameter = ProtocolMetadata.Deserialize<'parameter>(request)
+      let! result = handling.Invoke(parameter, cancellationToken)
+      return ProtocolMetadata.Serialize(result)
+    }
+
+  let invokeWithoutParameter<'server, 'result when 'server :> ILspServer>
+    (server: 'server)
+    (handlings: Map<string, Mappings.ServerRequestHandling<'server>>)
+    route
+    (cancellationToken: CancellationToken)
+    (_infer: unit -> AsyncLspResult<'result>)
+    =
+    task {
+      let handling = findHandling server handlings route :?> Func<unit, CancellationToken, Task<'result>>
+      let! result = handling.Invoke((), cancellationToken)
+      return ProtocolMetadata.Serialize(result)
+    }
+
+  let notifyWithParameter<'server, 'parameter when 'server :> ILspServer>
+    (server: 'server)
+    (handlings: Map<string, Mappings.ServerRequestHandling<'server>>)
+    route
+    (request: JsonElement)
+    (cancellationToken: CancellationToken)
+    (_infer: 'parameter -> Async<unit>)
+    : Task =
+    invokeWithParameter
+      server
+      handlings
+      route
+      request
+      cancellationToken
+      (fun parameter ->
+        async {
+          do! _infer parameter
+          return Ok()
+        }
+      )
+    :> Task
+
+  let notifyWithoutParameter<'server when 'server :> ILspServer>
+    (server: 'server)
+    (handlings: Map<string, Mappings.ServerRequestHandling<'server>>)
+    route
+    (cancellationToken: CancellationToken)
+    (_infer: unit -> Async<unit>)
+    : Task =
+    invokeWithoutParameter
+      server
+      handlings
+      route
+      cancellationToken
+      (fun () ->
+        async {
+          do! _infer ()
+          return Ok()
+        }
+      )
+    :> Task

--- a/src/AotTypes.fs
+++ b/src/AotTypes.fs
@@ -17,15 +17,11 @@ type U2<'T1, 'T2> =
   | C1 of 'T1
   | C2 of 'T2
 
-  override _.ToString() = "U2"
-
 [<ErasedUnion; System.Diagnostics.DebuggerDisplay("U3")>]
 type U3<'T1, 'T2, 'T3> =
   | C1 of 'T1
   | C2 of 'T2
   | C3 of 'T3
-
-  override _.ToString() = "U3"
 
 [<ErasedUnion; System.Diagnostics.DebuggerDisplay("U4")>]
 type U4<'T1, 'T2, 'T3, 'T4> =
@@ -33,8 +29,6 @@ type U4<'T1, 'T2, 'T3, 'T4> =
   | C2 of 'T2
   | C3 of 'T3
   | C4 of 'T4
-
-  override _.ToString() = "U4"
 
 /// A JSON value carried in an LSP `any` slot.
 [<Sealed>]

--- a/src/AotTypes.fs
+++ b/src/AotTypes.fs
@@ -1,0 +1,62 @@
+namespace Ionide.LanguageServerProtocol.Types
+
+open System
+open System.Text.Json
+
+/// Marks the fixed discriminator value of a protocol record used in an erased union.
+type UnionKindAttribute(value: string) =
+  inherit Attribute()
+  member _.Value = value
+
+/// Marks a protocol union whose case wrapper is erased on the JSON wire.
+type ErasedUnionAttribute() =
+  inherit Attribute()
+
+[<ErasedUnion; System.Diagnostics.DebuggerDisplay("U2")>]
+type U2<'T1, 'T2> =
+  | C1 of 'T1
+  | C2 of 'T2
+
+  override _.ToString() = "U2"
+
+[<ErasedUnion; System.Diagnostics.DebuggerDisplay("U3")>]
+type U3<'T1, 'T2, 'T3> =
+  | C1 of 'T1
+  | C2 of 'T2
+  | C3 of 'T3
+
+  override _.ToString() = "U3"
+
+[<ErasedUnion; System.Diagnostics.DebuggerDisplay("U4")>]
+type U4<'T1, 'T2, 'T3, 'T4> =
+  | C1 of 'T1
+  | C2 of 'T2
+  | C3 of 'T3
+  | C4 of 'T4
+
+  override _.ToString() = "U4"
+
+/// A JSON value carried in an LSP `any` slot.
+[<Sealed>]
+type LSPAny private (element: JsonElement) =
+  let element = element.Clone()
+
+  /// The underlying System.Text.Json value.
+  member _.JsonElement = element
+
+  override _.ToString() = element.GetRawText()
+
+  override _.GetHashCode() = StringComparer.Ordinal.GetHashCode(element.GetRawText())
+
+  override _.Equals(obj: obj) =
+    match obj with
+    | :? LSPAny as value -> StringComparer.Ordinal.Equals(element.GetRawText(), value.JsonElement.GetRawText())
+    | _ -> false
+
+  interface IEquatable<LSPAny> with
+    member _.Equals(other) =
+      not (obj.ReferenceEquals(other, null))
+      && StringComparer.Ordinal.Equals(element.GetRawText(), other.JsonElement.GetRawText())
+
+  /// Wraps a System.Text.Json value without retaining its owning JsonDocument.
+  static member fromJsonElement(element: JsonElement) = LSPAny(element)

--- a/src/ClientServer.cg.fs
+++ b/src/ClientServer.cg.fs
@@ -394,7 +394,12 @@ type ILspClient =
   abstract WorkspaceApplyEdit: ApplyWorkspaceEditParams -> AsyncLspResult<ApplyWorkspaceEditResult>
 
 module Mappings =
-  type ServerRequestHandling<'server when 'server :> ILspServer> = { Run: 'server -> System.Delegate }
+  type ServerRequestHandling<'server when 'server :> ILspServer> =
+    { Run: 'server -> System.Delegate }
+#if NET10_0
+
+    override _.ToString() = "ServerRequestHandling"
+#endif
 
   let routeMappings () =
     let serverRequestHandling run = {

--- a/src/FsLibLog.fs
+++ b/src/FsLibLog.fs
@@ -803,7 +803,12 @@ module LogProvider =
     // | Call (_, methInfo, _) -> sprintf "%s.%s" methInfo.DeclaringType.FullName methInfo.Name
     // | Lambda(_, expr) -> getModuleType expr
     // | ValueWithName(_,_,instance) -> instance
-    | x -> failwithf "Expression is not a property. %A" x
+    | x ->
+#if NET10_0
+      failwith $"Expression is not a property. {x}"
+#else
+      failwithf "Expression is not a property. %A" x
+#endif
 
   /// **Description**
   ///

--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ChangelogFile>$(MSBuildThisFileDirectory)../CHANGELOG.md</ChangelogFile>
     <Description>Library for implementing Language Server Protocol in F#.</Description>
@@ -11,6 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/ionide/LanguageServerProtocol</PackageProjectUrl>
     <LSPVersion>3.17.0</LSPVersion>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net10.0'">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <!-- FsLibLog.fs comes verbatim from
@@ -20,27 +21,64 @@
     repo.
     -->
     <Compile Include="FsLibLog.fs" />
-    <Compile Include="Types.fs" />
-    <Compile Include="Types.cg.fs" Watch="false" />
-    <Compile Include="JsonRpc.fs" />
+    <Compile Include="Types.fs" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Compile Include="Types.cg.fs" Watch="false" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Compile Include="JsonRpc.fs" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Compile Include="AotTypes.fs" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <Compile Include="$(IntermediateOutputPath)AotTypes.generated.fs" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <Compile Include="AotJsonRpc.fs" Condition="'$(TargetFramework)' == 'net10.0'" />
     <Compile Include="TypeDefaults.fs" />
     <Compile Include="ClientServer.cg.fs" Watch="false" />
     <Compile Include="Client.fs" />
     <Compile Include="Server.fs" />
-    <Compile Include="OptionConverter.fs" />
-    <Compile Include="JsonUtils.fs" />
-    <Compile Include="LanguageServerProtocol.fs" />
+    <Compile Include="OptionConverter.fs" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Compile Include="JsonUtils.fs" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Compile Include="AotRuntime.fs" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <Compile Include="$(IntermediateOutputPath)StaticProtocolTarget.generated.fs" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <Compile Include="LanguageServerProtocol.fs" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Compile Include="AotLanguageServerProtocol.fs" Condition="'$(TargetFramework)' == 'net10.0'" />
     <None Include="../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Text.Json" Version="10.0.10" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <!-- Explicitly pinning our FSharp.Core to 6.0.0 so that consumers can use _any_ 6.x version. -->
-    <PackageReference Update="FSharp.Core" Version="6.0.0" />
-    <PackageReference Include="StreamJsonRpc" Version="2.16.36" />
+    <PackageReference Update="FSharp.Core" Version="6.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Update="FSharp.Core" Version="10.1.301" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
+    <Reference Include="Ionide.LanguageServerProtocol.StaticMetadata" Condition="'$(TargetFramework)' == 'net10.0'">
+      <HintPath>$(MSBuildThisFileDirectory)StaticMetadata/bin/$(Configuration)/net10.0/Ionide.LanguageServerProtocol.StaticMetadata.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeStaticMetadataPackageAsset</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="GenerateAotMetadata" BeforeTargets="ResolveReferences" Condition="'$(TargetFramework)' == 'net10.0'">
+    <ItemGroup>
+      <_GeneratorProject Include="../tools/MetaModelGenerator/MetaModelGenerator.fsproj" />
+      <_AotContractProject Include="$(MSBuildThisFileDirectory)StaticMetadata/AotContract/AotContract.fsproj" />
+    </ItemGroup>
+    <MSBuild Projects="@(_GeneratorProject)" Targets="Restore;Build" RemoveProperties="TargetFramework">
+      <Output TaskParameter="TargetOutputs" ItemName="_AotGeneratorApp" />
+    </MSBuild>
+    <Exec Command="dotnet &quot;@(_AotGeneratorApp)&quot; aottypes --metamodelpath &quot;%(_MetaModelInputs.FullPath)&quot; --outputfilepath &quot;$(IntermediateOutputPath)AotTypes.generated.fs&quot;" />
+    <MSBuild Projects="@(_AotContractProject)" Targets="Restore;Build" Properties="Configuration=$(Configuration);TargetFramework=net10.0;ContractGeneratedTypesPath=$(MSBuildThisFileDirectory)$(IntermediateOutputPath)AotTypes.generated.fs;BuildProjectReferences=false;RuntimeIdentifier=;RuntimeIdentifiers=" />
+    <Exec Command="dotnet &quot;@(_AotGeneratorApp)&quot; aotmetadata --metamodelpath &quot;%(_MetaModelInputs.FullPath)&quot; --contractassemblypath &quot;$(MSBuildThisFileDirectory)StaticMetadata/AotContract/bin/$(Configuration)/net10.0/Ionide.LanguageServerProtocol.dll&quot; --csharpoutputfilepath &quot;$(IntermediateOutputPath)AotMetadata.generated.cs&quot; --fsharpoutputfilepath &quot;$(IntermediateOutputPath)StaticProtocolTarget.generated.fs&quot;" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)StaticMetadata/Ionide.LanguageServerProtocol.StaticMetadata.csproj" Targets="Restore;Build" Properties="Configuration=$(Configuration);TargetFramework=net10.0;ContractAssemblyPath=$(MSBuildThisFileDirectory)StaticMetadata/AotContract/bin/$(Configuration)/net10.0/Ionide.LanguageServerProtocol.dll;BuildProjectReferences=false;RuntimeIdentifier=;RuntimeIdentifiers=" />
+  </Target>
+
+  <Target Name="IncludeStaticMetadataPackageAsset" Condition="'$(TargetFramework)' == 'net10.0'">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(MSBuildThisFileDirectory)StaticMetadata/bin/$(Configuration)/net10.0/Ionide.LanguageServerProtocol.StaticMetadata.dll">
+        <TargetPath>Ionide.LanguageServerProtocol.StaticMetadata.dll</TargetPath>
+      </BuildOutputInPackage>
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <_MetaModelInputs
@@ -60,7 +98,7 @@
   </Target>
 
   <Target Name="RegenerateTypes" Inputs="@(_MetaModelInputs);@(_GenerationInputs)"
-    Condition="'$(DesignTimeBuild)' != 'True'"
+    Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(DesignTimeBuild)' != 'True'"
     DependsOnTargets="EnsureRegeneration"
     Outputs="@(_MetaModelOutputs); @(_MetaModelClientServerOutputs)"
     BeforeTargets="PrepareForBuild">

--- a/src/Ionide.LanguageServerProtocol.fsproj
+++ b/src/Ionide.LanguageServerProtocol.fsproj
@@ -12,9 +12,10 @@
     <PackageProjectUrl>https://github.com/ionide/LanguageServerProtocol</PackageProjectUrl>
     <LSPVersion>3.17.0</LSPVersion>
     <IsAotCompatible Condition="'$(TargetFramework)' == 'net10.0'">true</IsAotCompatible>
+    <OtherFlags Condition="'$(TargetFramework)' == 'net10.0'">$(OtherFlags) --reflectionfree</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
-    <!-- FsLibLog.fs comes verbatim from
+    <!-- FsLibLog.fs is based on
     https://github.com/TheAngryByrd/FsLibLog/blob/f81cba440bf0476bb4e2262b57a067a0d6ab78a7/src/FsLibLog/FsLibLog.fs
 
          Namespace changed from FsLibLog to LanguageServerProtocol.Logging per the instructions in that
@@ -58,7 +59,7 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeStaticMetadataPackageAsset</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
-  <Target Name="GenerateAotMetadata" BeforeTargets="ResolveReferences" Condition="'$(TargetFramework)' == 'net10.0'">
+  <Target Name="GenerateAotMetadata" BeforeTargets="ResolveAssemblyReferences" Condition="'$(TargetFramework)' == 'net10.0'">
     <ItemGroup>
       <_GeneratorProject Include="../tools/MetaModelGenerator/MetaModelGenerator.fsproj" />
       <_AotContractProject Include="$(MSBuildThisFileDirectory)StaticMetadata/AotContract/AotContract.fsproj" />

--- a/src/StaticMetadata/AotContract/AotContract.fsproj
+++ b/src/StaticMetadata/AotContract/AotContract.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>Ionide.LanguageServerProtocol</AssemblyName>
+    <RootNamespace>Ionide.LanguageServerProtocol</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../AotTypes.fs" Link="AotTypes.fs" />
+    <Compile Include="$(ContractGeneratedTypesPath)" Link="AotTypes.generated.fs" />
+    <Compile Include="../../AotJsonRpc.fs" Link="AotJsonRpc.fs" />
+    <Compile Include="../../ClientServer.cg.fs" Link="ClientServer.cg.fs" />
+    <PackageReference Update="FSharp.Core" Version="10.1.301" />
+    <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
+  </ItemGroup>
+</Project>

--- a/src/StaticMetadata/Ionide.LanguageServerProtocol.StaticMetadata.csproj
+++ b/src/StaticMetadata/Ionide.LanguageServerProtocol.StaticMetadata.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <EnableStreamJsonRpcInterceptors>true</EnableStreamJsonRpcInterceptors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ContractAssemblyPath>$(MSBuildThisFileDirectory)AotContract/bin/$(Configuration)/net10.0/Ionide.LanguageServerProtocol.dll</ContractAssemblyPath>
+    <GeneratedMetadataPath>$(MSBuildThisFileDirectory)../obj/$(Configuration)/net10.0/AotMetadata.generated.cs</GeneratedMetadataPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Ionide.LanguageServerProtocol">
+      <HintPath>$(ContractAssemblyPath)</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Compile Include="$(GeneratedMetadataPath)" Link="AotMetadata.generated.cs" />
+    <PackageReference Include="FSharp.Core" Version="10.1.301" />
+    <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
+  </ItemGroup>
+</Project>

--- a/src/StaticMetadata/ProtocolJsonConverters.cs
+++ b/src/StaticMetadata/ProtocolJsonConverters.cs
@@ -1,0 +1,263 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Ionide.LanguageServerProtocol.Types;
+using Microsoft.FSharp.Collections;
+using Microsoft.FSharp.Core;
+
+namespace Ionide.LanguageServerProtocol.StaticMetadata;
+
+internal class FSharpOptionJsonConverter<T> : JsonConverter<FSharpOption<T>>
+{
+  public override bool HandleNull => true;
+
+  public override FSharpOption<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  {
+    if (reader.TokenType == JsonTokenType.Null)
+    {
+      return FSharpOption<T>.None;
+    }
+
+    JsonTypeInfo<T> typeInfo = (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
+    T value = JsonSerializer.Deserialize(ref reader, typeInfo)!;
+    return FSharpOption<T>.Some(value);
+  }
+
+  public override void Write(Utf8JsonWriter writer, FSharpOption<T> value, JsonSerializerOptions options)
+  {
+    if (FSharpOption<T>.get_IsNone(value))
+    {
+      writer.WriteNullValue();
+      return;
+    }
+
+    JsonSerializer.Serialize(writer, value.Value, (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T)));
+  }
+}
+
+internal class FSharpMapJsonConverter<T> : JsonConverter<FSharpMap<string, T>>
+{
+  public override FSharpMap<string, T> Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+  {
+    if (reader.TokenType != JsonTokenType.StartObject)
+    {
+      throw new JsonException("A protocol map must be a JSON object.");
+    }
+
+    var values = new List<Tuple<string, T>>();
+    JsonTypeInfo<T> typeInfo = (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
+    while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+    {
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        throw new JsonException("Expected a protocol map key.");
+      }
+
+      string key = reader.GetString()!;
+      if (!reader.Read())
+        throw new JsonException("Expected a protocol map value.");
+      values.Add(Tuple.Create(key, JsonSerializer.Deserialize(ref reader, typeInfo)!));
+    }
+
+    return new FSharpMap<string, T>(values);
+  }
+
+  public override void Write(Utf8JsonWriter writer, FSharpMap<string, T> value, JsonSerializerOptions options)
+  {
+    JsonTypeInfo<T> typeInfo = (JsonTypeInfo<T>)options.GetTypeInfo(typeof(T));
+    writer.WriteStartObject();
+    foreach (KeyValuePair<string, T> item in value)
+    {
+      writer.WritePropertyName(item.Key);
+      JsonSerializer.Serialize(writer, item.Value, typeInfo);
+    }
+    writer.WriteEndObject();
+  }
+}
+
+internal abstract class ErasedUnionJsonConverter<TUnion> : JsonConverter<TUnion>
+{
+  protected abstract Type[] CandidateTypes { get; }
+  protected abstract string?[] UnionKinds { get; }
+  protected abstract TUnion Create(int index, object? value);
+  protected abstract object? GetValue(TUnion value);
+
+  public override TUnion Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  {
+    using JsonDocument document = JsonDocument.ParseValue(ref reader);
+    JsonElement element = document.RootElement;
+    int selected = SelectCandidate(element, options);
+    ProtocolMetadata.ValidateRequired(CandidateTypes[selected], element);
+    JsonTypeInfo typeInfo = options.GetTypeInfo(CandidateTypes[selected]);
+    object? value = JsonSerializer.Deserialize(element, typeInfo);
+    return Create(selected, value);
+  }
+
+  public override void Write(Utf8JsonWriter writer, TUnion value, JsonSerializerOptions options)
+  {
+    object? nested = GetValue(value);
+    if (nested is null)
+    {
+      writer.WriteNullValue();
+      return;
+    }
+
+    JsonSerializer.Serialize(writer, nested, options.GetTypeInfo(nested.GetType()));
+  }
+
+  private int SelectCandidate(JsonElement element, JsonSerializerOptions options)
+  {
+    for (int index = 0; index < CandidateTypes.Length; index++)
+    {
+      Type candidate = CandidateTypes[index];
+      if (
+        (element.ValueKind == JsonValueKind.String && candidate == typeof(string))
+        || (element.ValueKind == JsonValueKind.Number && IsNumber(candidate))
+        || (
+          (element.ValueKind == JsonValueKind.True || element.ValueKind == JsonValueKind.False)
+          && candidate == typeof(bool)
+        )
+        || (element.ValueKind == JsonValueKind.Array && candidate.IsArray)
+      )
+      {
+        return index;
+      }
+    }
+
+    if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty("kind", out JsonElement kindElement))
+    {
+      string? kind = kindElement.GetString();
+      for (int index = 0; index < UnionKinds.Length; index++)
+      {
+        if (UnionKinds[index] == kind)
+          return index;
+      }
+    }
+
+    if (element.ValueKind == JsonValueKind.Object)
+    {
+      foreach (int index in Enumerable.Range(0, CandidateTypes.Length))
+      {
+        JsonTypeInfo candidate = options.GetTypeInfo(CandidateTypes[index]);
+        if (candidate.Kind != JsonTypeInfoKind.Object)
+          continue;
+        bool matches = true;
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+          if (
+            !candidate.Properties.Any(candidateProperty =>
+              StringComparer.OrdinalIgnoreCase.Equals(candidateProperty.Name, property.Name)
+            )
+          )
+          {
+            matches = false;
+            break;
+          }
+        }
+
+        if (matches)
+          return index;
+      }
+    }
+
+    throw new JsonException($"No case of {typeof(TUnion)} accepts this JSON value.");
+  }
+
+  private static bool IsNumber(Type type) =>
+    type == typeof(byte)
+    || type == typeof(sbyte)
+    || type == typeof(short)
+    || type == typeof(ushort)
+    || type == typeof(int)
+    || type == typeof(uint)
+    || type == typeof(long)
+    || type == typeof(ulong)
+    || type == typeof(float)
+    || type == typeof(double)
+    || type == typeof(decimal);
+}
+
+internal class ErasedUnion2JsonConverter<T1, T2> : ErasedUnionJsonConverter<U2<T1, T2>>
+{
+  protected override Type[] CandidateTypes => [typeof(T1), typeof(T2)];
+  protected override string?[] UnionKinds => [null, null];
+
+  protected override U2<T1, T2> Create(int index, object? value) =>
+    index switch
+    {
+      0 => U2<T1, T2>.NewC1((T1)value!),
+      1 => U2<T1, T2>.NewC2((T2)value!),
+      _ => throw new JsonException(),
+    };
+
+  protected override object? GetValue(U2<T1, T2> value) =>
+    value switch
+    {
+      U2<T1, T2>.C1 first => first.Item,
+      U2<T1, T2>.C2 second => second.Item,
+      _ => throw new JsonException(),
+    };
+}
+
+internal class ErasedUnion3JsonConverter<T1, T2, T3> : ErasedUnionJsonConverter<U3<T1, T2, T3>>
+{
+  protected override Type[] CandidateTypes => [typeof(T1), typeof(T2), typeof(T3)];
+  protected override string?[] UnionKinds => [null, null, null];
+
+  protected override U3<T1, T2, T3> Create(int index, object? value) =>
+    index switch
+    {
+      0 => U3<T1, T2, T3>.NewC1((T1)value!),
+      1 => U3<T1, T2, T3>.NewC2((T2)value!),
+      2 => U3<T1, T2, T3>.NewC3((T3)value!),
+      _ => throw new JsonException(),
+    };
+
+  protected override object? GetValue(U3<T1, T2, T3> value) =>
+    value switch
+    {
+      U3<T1, T2, T3>.C1 item => item.Item,
+      U3<T1, T2, T3>.C2 item => item.Item,
+      U3<T1, T2, T3>.C3 item => item.Item,
+      _ => throw new JsonException(),
+    };
+}
+
+internal class ErasedUnion4JsonConverter<T1, T2, T3, T4> : ErasedUnionJsonConverter<U4<T1, T2, T3, T4>>
+{
+  protected override Type[] CandidateTypes => [typeof(T1), typeof(T2), typeof(T3), typeof(T4)];
+  protected override string?[] UnionKinds => [null, null, null, null];
+
+  protected override U4<T1, T2, T3, T4> Create(int index, object? value) =>
+    index switch
+    {
+      0 => U4<T1, T2, T3, T4>.NewC1((T1)value!),
+      1 => U4<T1, T2, T3, T4>.NewC2((T2)value!),
+      2 => U4<T1, T2, T3, T4>.NewC3((T3)value!),
+      3 => U4<T1, T2, T3, T4>.NewC4((T4)value!),
+      _ => throw new JsonException(),
+    };
+
+  protected override object? GetValue(U4<T1, T2, T3, T4> value) =>
+    value switch
+    {
+      U4<T1, T2, T3, T4>.C1 item => item.Item,
+      U4<T1, T2, T3, T4>.C2 item => item.Item,
+      U4<T1, T2, T3, T4>.C3 item => item.Item,
+      U4<T1, T2, T3, T4>.C4 item => item.Item,
+      _ => throw new JsonException(),
+    };
+}
+
+internal sealed class LspAnyJsonConverter : JsonConverter<LSPAny>
+{
+  public override LSPAny Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+    LSPAny.fromJsonElement(JsonElement.ParseValue(ref reader));
+
+  public override void Write(Utf8JsonWriter writer, LSPAny value, JsonSerializerOptions options) =>
+    value.JsonElement.WriteTo(writer);
+}

--- a/src/TypeDefaults.fs
+++ b/src/TypeDefaults.fs
@@ -144,6 +144,9 @@ module Extensions =
       Data = None
     }
 
+#if NET10_0
+  [<System.Diagnostics.DebuggerDisplay("{__DebugDisplay(),nq}")>]
+#endif
   type WorkDoneProgressKind =
     | Begin
     | Report
@@ -154,6 +157,14 @@ module Extensions =
       | Begin -> "begin"
       | Report -> "report"
       | End -> "end"
+
+#if NET10_0
+    member private x.__DebugDisplay() =
+      match x with
+      | Begin -> "Begin"
+      | Report -> "Report"
+      | End -> "End"
+#endif
 
   type WorkDoneProgressEnd with
     static member Create(?message) = { Kind = WorkDoneProgressKind.End.ToString(); Message = message }

--- a/tests/AotProtocolTests.fs
+++ b/tests/AotProtocolTests.fs
@@ -1,0 +1,149 @@
+module Ionide.LanguageServerProtocol.Tests.AotProtocolTests
+
+open System
+open System.Globalization
+open System.IO
+open System.IO.Pipes
+open System.Text
+open System.Threading.Tasks
+open Expecto
+open Ionide.LanguageServerProtocol
+open Ionide.LanguageServerProtocol.JsonRpc
+open Ionide.LanguageServerProtocol.Types
+
+let private waitTimeout = TimeSpan.FromSeconds 5.0
+
+let private frame (json: string) =
+  String.Concat(
+    "Content-Length: ",
+    Encoding.UTF8.GetByteCount(json).ToString(CultureInfo.InvariantCulture),
+    "\r\n\r\n",
+    json
+  )
+
+let private writeMessage (stream: Stream) json =
+  let bytes =
+    json
+    |> frame
+    |> Encoding.UTF8.GetBytes
+
+  stream.Write(bytes, 0, bytes.Length)
+  stream.Flush()
+
+type private ProtocolClient(notificationSender: Server.ClientNotificationSender) =
+  inherit LspClient()
+
+  override _.WindowLogMessage(parameters) =
+    async {
+      let! result = notificationSender "window/logMessage" parameters
+
+      match result with
+      | Ok() -> return ()
+      | Error error -> return failwith error.Message
+    }
+
+type private ProtocolServer
+  (
+    client: ILspClient,
+    initialized: TaskCompletionSource<string option>,
+    documentOpened: TaskCompletionSource<string>,
+    shutdown: TaskCompletionSource<unit>
+  ) =
+  inherit LspServer()
+
+  override _.Dispose() = ()
+
+  override _.Initialize(parameters) =
+    async {
+      do! client.WindowLogMessage { Type = MessageType.Info; Message = "server ready" }
+
+      parameters.ClientInfo
+      |> Option.map _.Name
+      |> initialized.SetResult
+
+      return LspResult.success InitializeResult.Default
+    }
+
+  override _.TextDocumentDidOpen(parameters) =
+    parameters.TextDocument.Uri
+    |> documentOpened.SetResult
+
+    async.Return()
+
+  override _.Shutdown() =
+    shutdown.SetResult()
+    AsyncLspResult.success ()
+
+[<Tests>]
+let tests =
+  testList "protocol" [
+    testCaseAsync "handles a complete protocol session"
+    <| async {
+      let initialized = TaskCompletionSource<string option>(TaskCreationOptions.RunContinuationsAsynchronously)
+      let documentOpened = TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously)
+      let shutdown = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+      use serverInput = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.None)
+      use clientOutput = new AnonymousPipeClientStream(PipeDirection.Out, serverInput.GetClientHandleAsString())
+      use serverOutput = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.None)
+      use clientInput = new AnonymousPipeClientStream(PipeDirection.In, serverOutput.GetClientHandleAsString())
+      use outputReader = new StreamReader(clientInput, Encoding.UTF8)
+
+      let outputTask = outputReader.ReadToEndAsync()
+
+      let serverTask =
+        Task.Run(fun () ->
+          Server.start
+            (Server.defaultRequestHandlings ())
+            serverInput
+            serverOutput
+            (fun (notificationSender, _) -> new ProtocolClient(notificationSender))
+            (fun client -> new ProtocolServer(client, initialized, documentOpened, shutdown))
+        )
+
+      writeMessage
+        clientOutput
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"regression client"},"capabilities":{}}}"""
+
+      let! clientName =
+        initialized.Task.WaitAsync(waitTimeout)
+        |> Async.AwaitTask
+
+      Expect.equal clientName (Some "regression client") "initialize parameters should reach the server"
+
+      writeMessage
+        clientOutput
+        """{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///protocol.fs","languageId":"fsharp","version":1,"text":"let value = 1"}}}"""
+
+      let! openedUri =
+        documentOpened.Task.WaitAsync(waitTimeout)
+        |> Async.AwaitTask
+
+      Expect.equal openedUri "file:///protocol.fs" "notifications should reach the server"
+
+      writeMessage clientOutput """{"jsonrpc":"2.0","id":2,"method":"shutdown"}"""
+
+      do!
+        shutdown.Task.WaitAsync(waitTimeout)
+        |> Async.AwaitTask
+
+      writeMessage clientOutput """{"jsonrpc":"2.0","method":"exit"}"""
+
+      let! closeReason =
+        serverTask.WaitAsync(waitTimeout)
+        |> Async.AwaitTask
+
+      let! output =
+        outputTask.WaitAsync(waitTimeout)
+        |> Async.AwaitTask
+
+      Expect.equal closeReason Server.LspCloseReason.RequestedByClient "shutdown followed by exit should close cleanly"
+      Expect.stringContains output "\"id\":1" "initialize should receive a response"
+      Expect.stringContains output "\"id\":2" "shutdown should receive a response"
+      Expect.stringContains output "\"method\":\"window/logMessage\"" "the server should send client traffic"
+      Expect.stringContains output "\"message\":\"server ready\"" "outbound parameters should be serialized"
+    }
+  ]
+
+[<EntryPoint>]
+let main args = runTestsWithCLIArgs [ Sequenced ] args tests

--- a/tests/Ionide.LanguageServerProtocol.Tests.fsproj
+++ b/tests/Ionide.LanguageServerProtocol.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 

--- a/tests/Ionide.LanguageServerProtocol.Tests.fsproj
+++ b/tests/Ionide.LanguageServerProtocol.Tests.fsproj
@@ -2,17 +2,21 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <Compile Include="Utils.fs" />
     <Compile Include="Benchmarks.fs" />
     <Compile Include="Shotgun.fs" />
     <Compile Include="StartWithSetup.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <Compile Include="AotProtocolTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/MetaModelGenerator/GenerateAotMetadata.fs
+++ b/tools/MetaModelGenerator/GenerateAotMetadata.fs
@@ -1,0 +1,805 @@
+namespace MetaModelGenerator
+
+module GenerateAotMetadata =
+  open System
+  open System.IO
+  open System.Reflection
+  open System.Text
+  open Microsoft.FSharp.Reflection
+
+  let private normalizeMethod (value: string) =
+    value.Split(
+      '/',
+      StringSplitOptions.RemoveEmptyEntries
+      ||| StringSplitOptions.TrimEntries
+    )
+    |> Array.filter ((<>) "$")
+    |> Array.map (fun part ->
+      Char.ToUpperInvariant(part.[0]).ToString()
+      + part.Substring(1)
+    )
+    |> String.concat ""
+
+  let private csharpTypeName (ty: Type) =
+    let rec render (value: Type) =
+      if value.IsArray then
+        render (value.GetElementType())
+        + "[]"
+      elif value.IsGenericType then
+        let definitionName = value.GetGenericTypeDefinition().FullName
+        let tick = definitionName.IndexOf('`')
+        let name = definitionName.Substring(0, tick).Replace('+', '.')
+
+        let arguments =
+          value.GetGenericArguments()
+          |> Array.map render
+          |> String.concat ", "
+
+        $"global::{name}<{arguments}>"
+      else
+        $"global::{value.FullName.Replace('+', '.')}"
+
+    render ty
+
+  let private isClosedProtocolType (ty: Type) =
+    not ty.ContainsGenericParameters
+    && not ty.IsPointer
+    && not ty.IsByRef
+    && ty
+       <> typeof<Void>
+    && ty
+       <> typeof<obj>
+
+  let private collectTypes (assembly: Assembly) =
+    let optionDefinition = typedefof<option<_>>
+    let mapDefinition = typedefof<Map<_, _>>
+    let protocolNamespace = "Ionide.LanguageServerProtocol.Types"
+    let mutable seen = Set.empty<string>
+    let mutable closedSpecials = Map.empty<string, Type>
+
+    let rec visit (ty: Type) =
+      if
+        isNull ty
+        || not (isClosedProtocolType ty)
+      then
+        ()
+      else
+        let key = ty.AssemblyQualifiedName
+
+        if
+          not (isNull key)
+          && not (Set.contains key seen)
+        then
+          seen <- Set.add key seen
+
+          if ty.IsArray then
+            visit (ty.GetElementType())
+          elif ty.IsGenericType then
+            let definition = ty.GetGenericTypeDefinition()
+
+            if
+              definition = optionDefinition
+              || definition = mapDefinition
+              || (not (isNull definition.FullName)
+                  && definition.FullName.StartsWith("Ionide.LanguageServerProtocol.Types.U", StringComparison.Ordinal))
+            then
+              closedSpecials <- Map.add key ty closedSpecials
+
+            ty.GetGenericArguments()
+            |> Array.iter visit
+
+          if
+            ty.Namespace = protocolNamespace
+            && not ty.IsGenericTypeDefinition
+          then
+            ty.GetProperties(
+              BindingFlags.Public
+              ||| BindingFlags.Instance
+            )
+            |> Array.iter (fun property -> visit property.PropertyType)
+
+    let roots =
+      assembly.GetExportedTypes()
+      |> Array.filter (fun ty ->
+        ty.Namespace = protocolNamespace
+        && not ty.IsGenericTypeDefinition
+        && not ty.IsInterface
+        && not (
+          ty.IsAbstract
+          && ty.IsSealed
+        )
+        && not (typeof<Attribute>.IsAssignableFrom ty)
+        && not (ty.Name.EndsWith("Converter", StringComparison.Ordinal))
+      )
+
+    roots
+    |> Array.iter visit
+
+    for contractName in
+      [
+        "Ionide.LanguageServerProtocol.ILspServer"
+        "Ionide.LanguageServerProtocol.ILspClient"
+      ] do
+      let contract = assembly.GetType(contractName, true)
+
+      for methodInfo in contract.GetMethods() do
+        methodInfo.GetParameters()
+        |> Array.iter (fun parameter -> visit parameter.ParameterType)
+
+        visit methodInfo.ReturnType
+
+    roots
+    |> Array.sortBy _.FullName,
+    closedSpecials
+    |> Map.toArray
+    |> Array.map snd
+
+  let private enumMemberValue (field: FieldInfo) =
+    field.CustomAttributes
+    |> Seq.tryFind (fun attribute ->
+      attribute.AttributeType.FullName = "System.Runtime.Serialization.EnumMemberAttribute"
+    )
+    |> Option.bind (fun attribute ->
+      attribute.NamedArguments
+      |> Seq.tryFind (fun argument -> argument.MemberName = "Value")
+      |> Option.map (fun argument -> string argument.TypedValue.Value)
+    )
+    |> Option.defaultValue field.Name
+
+  let private unionKindValue (ty: Type) =
+    ty.GetProperties(
+      BindingFlags.Public
+      ||| BindingFlags.Instance
+    )
+    |> Array.tryPick (fun property ->
+      property.CustomAttributes
+      |> Seq.tryFind (fun attribute ->
+        attribute.AttributeType.FullName = "Ionide.LanguageServerProtocol.Types.UnionKindAttribute"
+      )
+      |> Option.bind (fun attribute ->
+        attribute.ConstructorArguments
+        |> Seq.tryHead
+        |> Option.map (fun argument -> string argument.Value)
+      )
+    )
+
+  let private escape (value: string) = value.Replace("\\", "\\\\").Replace("\"", "\\\"")
+
+  let private generateCSharp (assembly: Assembly) (metaModel: MetaModel.MetaModel) =
+    let roots, specials = collectTypes assembly
+
+    let validationTypes =
+      let mutable seen = Set.empty<string>
+      let collected = ResizeArray<Type>()
+
+      let rec visit (ty: Type) =
+        if
+          not (isNull ty)
+          && isClosedProtocolType ty
+        then
+          let key = ty.AssemblyQualifiedName
+
+          if
+            not (isNull key)
+            && not (Set.contains key seen)
+          then
+            seen <- Set.add key seen
+            collected.Add ty
+
+            if ty.IsArray then
+              visit (ty.GetElementType())
+            elif ty.IsGenericType then
+              ty.GetGenericArguments()
+              |> Array.iter visit
+
+            if
+              FSharpType.IsRecord(
+                ty,
+                BindingFlags.Public
+                ||| BindingFlags.NonPublic
+              )
+            then
+              FSharpType.GetRecordFields(
+                ty,
+                BindingFlags.Public
+                ||| BindingFlags.NonPublic
+              )
+              |> Array.iter (fun property -> visit property.PropertyType)
+
+      roots
+      |> Array.iter visit
+
+      specials
+      |> Array.iter visit
+
+      collected
+      |> Seq.sortBy csharpTypeName
+      |> Seq.toArray
+
+    let enums =
+      roots
+      |> Array.filter (fun ty ->
+        ty.IsEnum
+        && ty.GetFields(
+             BindingFlags.Public
+             ||| BindingFlags.Static
+           )
+           |> Array.exists (fun field ->
+             field.CustomAttributes
+             |> Seq.exists (fun attribute ->
+               attribute.AttributeType.FullName = "System.Runtime.Serialization.EnumMemberAttribute"
+             )
+           )
+      )
+
+    let optionDefinition = typedefof<option<_>>
+    let mapDefinition = typedefof<Map<_, _>>
+
+    let options =
+      specials
+      |> Array.filter (fun ty ->
+        ty.IsGenericType
+        && ty.GetGenericTypeDefinition() = optionDefinition
+      )
+
+    let maps =
+      specials
+      |> Array.filter (fun ty ->
+        ty.IsGenericType
+        && ty.GetGenericTypeDefinition() = mapDefinition
+      )
+
+    let unions =
+      specials
+      |> Array.filter (fun ty ->
+        ty.IsGenericType
+        && ty
+          .GetGenericTypeDefinition()
+          .FullName.StartsWith("Ionide.LanguageServerProtocol.Types.U", StringComparison.Ordinal)
+      )
+
+    let records =
+      validationTypes
+      |> Array.filter (fun ty ->
+        FSharpType.IsRecord(
+          ty,
+          BindingFlags.Public
+          ||| BindingFlags.NonPublic
+        )
+      )
+
+    let validationOptions =
+      validationTypes
+      |> Array.filter (fun ty ->
+        ty.IsGenericType
+        && ty.GetGenericTypeDefinition() = optionDefinition
+      )
+
+    let validationMaps =
+      validationTypes
+      |> Array.filter (fun ty ->
+        ty.IsGenericType
+        && ty.GetGenericTypeDefinition() = mapDefinition
+        && ty.GetGenericArguments().[0] = typeof<string>
+      )
+
+    let validationArrays =
+      validationTypes
+      |> Array.filter _.IsArray
+
+    let serverRequests =
+      metaModel.Requests
+      |> Array.filter Proposed.checkProposed
+      |> Array.filter (fun request ->
+        request.MessageDirection = MetaModel.MessageDirection.ClientToServer
+        || request.MessageDirection = MetaModel.MessageDirection.Both
+      )
+
+    let serverNotifications =
+      metaModel.Notifications
+      |> Array.filter Proposed.checkProposed
+      |> Array.filter (fun notification ->
+        notification.MessageDirection = MetaModel.MessageDirection.ClientToServer
+        || notification.MessageDirection = MetaModel.MessageDirection.Both
+      )
+
+    let builder = StringBuilder()
+
+    let line (text: string) =
+      builder.AppendLine(text)
+      |> ignore
+
+    line "// <auto-generated />"
+    line "#nullable enable"
+    line "using System.Diagnostics.CodeAnalysis;"
+    line "using System.Runtime.CompilerServices;"
+    line "using System.Text.Json;"
+    line "using System.Text.Json.Serialization;"
+    line "using System.Text.Json.Serialization.Metadata;"
+    line "using Microsoft.FSharp.Collections;"
+    line "using Microsoft.FSharp.Core;"
+    line "using PolyType;"
+    line "using StreamJsonRpc;"
+    line "[assembly: InternalsVisibleTo(\"Ionide.LanguageServerProtocol\")]"
+    line "namespace Ionide.LanguageServerProtocol.StaticMetadata;"
+    line ""
+    line "[GenerateShape(IncludeMethods = MethodShapeFlags.PublicInstance)]"
+    line "internal abstract partial class ProtocolTargetContract"
+    line "{"
+
+    for request in serverRequests do
+      let name = normalizeMethod request.Method
+
+      let parameter =
+        if Array.isEmpty request.ParamsSafe then
+          ""
+        else
+          "JsonElement request, "
+
+      let singleParameter =
+        if Array.isEmpty request.ParamsSafe then
+          ""
+        else
+          ", UseSingleObjectParameterDeserialization = true"
+
+      line $"    [JsonRpcMethod(\"{escape request.Method}\"{singleParameter})]"
+      line $"    public abstract Task<JsonElement> {name}Async({parameter}CancellationToken cancellationToken);"
+
+    for notification in serverNotifications do
+      let name = normalizeMethod notification.Method
+
+      let parameter =
+        if Array.isEmpty notification.ParamsSafe then
+          ""
+        else
+          "JsonElement request, "
+
+      let singleParameter =
+        if Array.isEmpty notification.ParamsSafe then
+          ""
+        else
+          ", UseSingleObjectParameterDeserialization = true"
+
+      line $"    [JsonRpcMethod(\"{escape notification.Method}\"{singleParameter})]"
+      line $"    public abstract Task {name}Async({parameter}CancellationToken cancellationToken);"
+
+    line "}"
+    line ""
+
+    let converterNames = ResizeArray<string>()
+
+    options
+    |> Array.iteri (fun index ty ->
+      let name = $"OptionConverter{index}"
+      converterNames.Add name
+
+      line
+        $"internal sealed class {name} : FSharpOptionJsonConverter<{csharpTypeName (ty.GetGenericArguments().[0])}> {{ }}"
+    )
+
+    maps
+    |> Array.iteri (fun index ty ->
+      let args = ty.GetGenericArguments()
+
+      if args.[0] = typeof<string> then
+        let name = $"MapConverter{index}"
+        converterNames.Add name
+        line $"internal sealed class {name} : FSharpMapJsonConverter<{csharpTypeName args.[1]}> {{ }}"
+    )
+
+    unions
+    |> Array.iteri (fun index ty ->
+      let args = ty.GetGenericArguments()
+      let name = $"UnionConverter{index}"
+      converterNames.Add name
+
+      let kinds =
+        args
+        |> Array.map unionKindValue
+        |> Array.map (
+          Option.map (fun value -> $"\"{escape value}\"")
+          >> Option.defaultValue "null"
+        )
+        |> String.concat ", "
+
+      let typeArguments =
+        args
+        |> Array.map csharpTypeName
+        |> String.concat ", "
+
+      let baseName = $"ErasedUnion{args.Length}JsonConverter<{typeArguments}>"
+
+      line
+        $"internal sealed class {name} : {baseName} {{ protected override string?[] UnionKinds => new string?[] {{ {kinds} }}; }}"
+    )
+
+    enums
+    |> Array.iteri (fun index ty ->
+      let name = $"EnumConverter{index}"
+      converterNames.Add name
+      line $"internal sealed class {name} : JsonConverter<{csharpTypeName ty}>"
+      line "{"
+
+      line
+        $"    public override {csharpTypeName ty} Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.GetString() switch"
+
+      line "    {"
+
+      for field in
+        ty.GetFields(
+          BindingFlags.Public
+          ||| BindingFlags.Static
+        ) do
+        line $"        \"{escape (enumMemberValue field)}\" => {csharpTypeName ty}.{field.Name},"
+
+      line "        _ => throw new JsonException(\"Unknown protocol enumeration value.\"),"
+      line "    };"
+
+      line
+        $"    public override void Write(Utf8JsonWriter writer, {csharpTypeName ty} value, JsonSerializerOptions options)"
+
+      line "    {"
+      line "        writer.WriteStringValue(value switch"
+      line "        {"
+
+      for field in
+        ty.GetFields(
+          BindingFlags.Public
+          ||| BindingFlags.Static
+        ) do
+        line $"            {csharpTypeName ty}.{field.Name} => \"{escape (enumMemberValue field)}\","
+
+      line "            _ => throw new JsonException(\"Unknown protocol enumeration value.\"),"
+      line "        });"
+      line "    }"
+      line "}"
+    )
+
+    converterNames.Add "LspAnyJsonConverter"
+
+    let converters =
+      converterNames
+      |> Seq.map (fun name -> $"typeof({name})")
+      |> String.concat ", "
+
+    line ""
+
+    line
+      $"[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNameCaseInsensitive = true, RespectRequiredConstructorParameters = false, Converters = new[] {{ {converters} }})]"
+
+    for index, ty in Array.indexed roots do
+      line $"[JsonSerializable(typeof({csharpTypeName ty}), TypeInfoPropertyName = \"ProtocolType{index}\")]"
+
+    for index, ty in Array.indexed specials do
+      line $"[JsonSerializable(typeof({csharpTypeName ty}), TypeInfoPropertyName = \"ProtocolSpecialType{index}\")]"
+
+    line "[JsonSerializable(typeof(JsonElement))]"
+    line "internal partial class ProtocolJsonSerializerContext : JsonSerializerContext;"
+    line ""
+    line "internal static class ProtocolMetadata"
+    line "{"
+
+    line
+      "    internal static IJsonTypeInfoResolver Resolver { get; } = ProtocolJsonSerializerContext.Default.WithAddedModifier(static typeInfo =>"
+
+    line "    {"
+    line "        if (typeInfo.Kind != JsonTypeInfoKind.Object) return;"
+    line "        foreach (JsonPropertyInfo property in typeInfo.Properties) property.IsRequired = false;"
+    line "    });"
+
+    line "    private static JsonSerializerOptions SerializerOptions { get; } = CreateSerializerOptions();"
+
+    line
+      "    internal static RpcTargetMetadata Target { get; } = RpcTargetMetadata.FromShape<ProtocolTargetContract>();"
+
+    line ""
+    line "    private static JsonSerializerOptions CreateSerializerOptions()"
+    line "    {"
+    line "        var options = new JsonSerializerOptions(ProtocolJsonSerializerContext.Default.Options);"
+    line "        options.TypeInfoResolver = Resolver;"
+    line "        return options;"
+    line "    }"
+
+    line ""
+    line "    internal static void Configure(JsonSerializerOptions options)"
+    line "    {"
+    line "        options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;"
+    line "        options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;"
+    line "        options.PropertyNameCaseInsensitive = true;"
+    line "        options.TypeInfoResolver = Resolver;"
+
+    line
+      "        foreach (JsonConverter converter in ProtocolJsonSerializerContext.Default.Options.Converters) options.Converters.Add(converter);"
+
+    line "    }"
+
+    line "    internal static JsonElement Serialize(object? value)"
+    line "    {"
+
+    line "        if (value is null) return JsonDocument.Parse(\"null\").RootElement.Clone();"
+
+    line
+      "        return JsonSerializer.SerializeToElement(value, SerializerOptions.GetTypeInfo(value.GetType()) ?? throw new JsonException($\"No generated JSON metadata for {value.GetType()}.\"));"
+
+    line "    }"
+
+    line "    internal static T Deserialize<T>(JsonElement value)"
+    line "    {"
+    line "        ValidateRequired(typeof(T), value);"
+
+    line
+      "        return JsonSerializer.Deserialize(value, (JsonTypeInfo<T>)(SerializerOptions.GetTypeInfo(typeof(T)) ?? throw new JsonException($\"No generated JSON metadata for {typeof(T)}.\")))!;"
+
+    line "    }"
+    line ""
+    line "    internal static void ValidateRequired(Type type, JsonElement value)"
+    line "    {"
+
+    for ty in validationOptions do
+      let valueType = ty.GetGenericArguments().[0]
+      line $"        if (type == typeof({csharpTypeName ty}))"
+      line "        {"
+      line "            if (value.ValueKind != JsonValueKind.Null)"
+      line "            {"
+      line $"                ValidateRequired(typeof({csharpTypeName valueType}), value);"
+      line "            }"
+      line ""
+      line "            return;"
+      line "        }"
+
+    for ty in validationArrays do
+      let elementType = ty.GetElementType()
+      line $"        if (type == typeof({csharpTypeName ty}))"
+      line "        {"
+      line "            if (value.ValueKind == JsonValueKind.Array)"
+      line "            {"
+      line "                foreach (JsonElement element in value.EnumerateArray())"
+      line "                {"
+      line $"                    ValidateRequired(typeof({csharpTypeName elementType}), element);"
+      line "                }"
+      line "            }"
+      line ""
+      line "            return;"
+      line "        }"
+
+    for ty in validationMaps do
+      let valueType = ty.GetGenericArguments().[1]
+      line $"        if (type == typeof({csharpTypeName ty}))"
+      line "        {"
+      line "            if (value.ValueKind == JsonValueKind.Object)"
+      line "            {"
+      line "                foreach (JsonProperty property in value.EnumerateObject())"
+      line "                {"
+      line $"                    ValidateRequired(typeof({csharpTypeName valueType}), property.Value);"
+      line "                }"
+      line "            }"
+      line ""
+      line "            return;"
+      line "        }"
+
+    for ty in records do
+      let properties =
+        FSharpType.GetRecordFields(
+          ty,
+          BindingFlags.Public
+          ||| BindingFlags.NonPublic
+        )
+
+      line $"        if (type == typeof({csharpTypeName ty}))"
+      line "        {"
+
+      properties
+      |> Array.iteri (fun index property ->
+        let propertyName = System.Text.Json.JsonNamingPolicy.CamelCase.ConvertName(property.Name)
+
+        let isOptional =
+          property.PropertyType.IsGenericType
+          && property.PropertyType.GetGenericTypeDefinition() = optionDefinition
+
+        if isOptional then
+          line $"            if (TryGetProperty(value, \"{escape propertyName}\", out JsonElement property{index}))"
+
+          line "            {"
+
+          line $"                ValidateRequired(typeof({csharpTypeName property.PropertyType}), property{index});"
+
+          line "            }"
+        else
+          line $"            JsonElement property{index} = RequireProperty(value, \"{escape propertyName}\");"
+
+          line $"            ValidateRequired(typeof({csharpTypeName property.PropertyType}), property{index});"
+      )
+
+      line ""
+      line "            return;"
+      line "        }"
+
+    line "    }"
+    line ""
+    line "    private static JsonElement RequireProperty(JsonElement value, string name)"
+    line "    {"
+    line "        if (TryGetProperty(value, name, out JsonElement property)) return property;"
+    line "        throw new JsonException(string.Concat(\"Required property '\", name, \"' is missing.\"));"
+    line "    }"
+    line ""
+    line "    private static bool TryGetProperty(JsonElement value, string name, out JsonElement result)"
+    line "    {"
+    line "        if (value.ValueKind == JsonValueKind.Object)"
+    line "        {"
+    line "            foreach (JsonProperty property in value.EnumerateObject())"
+    line "            {"
+    line "                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))"
+    line "                {"
+    line "                    result = property.Value;"
+    line "                    return true;"
+    line "                }"
+    line "            }"
+    line "        }"
+    line ""
+    line "        result = default;"
+    line "        return false;"
+    line "    }"
+
+    line
+      "    internal static Task NotifyAsync(global::StreamJsonRpc.JsonRpc rpc, string method, JsonElement value) => rpc.NotifyWithParameterObjectAsync(method, NamedArguments(value), NamedArgumentTypes(value));"
+
+    line
+      "    internal static Task<JsonElement> InvokeAsync(global::StreamJsonRpc.JsonRpc rpc, string method, JsonElement value) => rpc.InvokeWithParameterObjectAsync<JsonElement>(method, NamedArguments(value), NamedArgumentTypes(value), CancellationToken.None);"
+
+    line ""
+
+    line "    private static IReadOnlyDictionary<string, object?> NamedArguments(JsonElement value)"
+
+    line "    {"
+
+    line
+      "        if (value.ValueKind != JsonValueKind.Object) throw new JsonException(\"Protocol parameters must be a JSON object.\");"
+
+    line "        var arguments = new Dictionary<string, object?>();"
+
+    line
+      "        foreach (JsonProperty property in value.EnumerateObject()) arguments.Add(property.Name, property.Value);"
+
+    line "        return arguments;"
+    line "    }"
+    line ""
+
+    line "    private static IReadOnlyDictionary<string, Type> NamedArgumentTypes(JsonElement value)"
+
+    line "    {"
+
+    line
+      "        if (value.ValueKind != JsonValueKind.Object) throw new JsonException(\"Protocol parameters must be a JSON object.\");"
+
+    line "        var types = new Dictionary<string, Type>();"
+
+    line
+      "        foreach (JsonProperty property in value.EnumerateObject()) types.Add(property.Name, typeof(JsonElement));"
+
+    line "        return types;"
+    line "    }"
+
+    line "}"
+    line ""
+    line "internal static class FormatterFactory"
+    line "{"
+
+    line
+      "    [UnconditionalSuppressMessage(\"Trimming\", \"IL2026\", Justification = \"The generated JsonSerializerContext and static RPC metadata close the protocol graph.\")]"
+
+    line
+      "    [UnconditionalSuppressMessage(\"AOT\", \"IL3050\", Justification = \"The generated JsonSerializerContext and static RPC metadata close the protocol graph.\")]"
+
+    line "    internal static IJsonRpcMessageFormatter Create()"
+    line "    {"
+    line "        var formatter = new SystemTextJsonFormatter();"
+    line "        ProtocolMetadata.Configure(formatter.JsonSerializerOptions);"
+    line "        return formatter;"
+    line "    }"
+
+    line "}"
+
+    builder.ToString()
+
+  let private generateFSharp (metaModel: MetaModel.MetaModel) =
+    let serverRequests =
+      metaModel.Requests
+      |> Array.filter Proposed.checkProposed
+      |> Array.filter (fun request ->
+        request.MessageDirection = MetaModel.MessageDirection.ClientToServer
+        || request.MessageDirection = MetaModel.MessageDirection.Both
+      )
+
+    let serverNotifications =
+      metaModel.Notifications
+      |> Array.filter Proposed.checkProposed
+      |> Array.filter (fun notification ->
+        notification.MessageDirection = MetaModel.MessageDirection.ClientToServer
+        || notification.MessageDirection = MetaModel.MessageDirection.Both
+      )
+
+    let builder = StringBuilder()
+
+    let line (text: string) =
+      builder.AppendLine(text)
+      |> ignore
+
+    line "// <auto-generated />"
+    line "namespace Ionide.LanguageServerProtocol"
+    line "open System"
+    line "open System.Text.Json"
+    line "open System.Threading"
+    line "open System.Threading.Tasks"
+    line "open Ionide.LanguageServerProtocol.StaticMetadata"
+    line ""
+    line "type internal StaticProtocolTarget<'server when 'server :> ILspServer>"
+
+    line
+      "  (server: 'server, handlings: Map<string, Mappings.ServerRequestHandling<'server>>, onShutdown: Action, onExit: Action) ="
+
+    line "  inherit ProtocolTargetContract()"
+
+    for request in serverRequests do
+      let name = normalizeMethod request.Method
+      let route = escape request.Method
+
+      if request.Method = "shutdown" then
+        line $"  override _.{name}Async(cancellationToken) ="
+        line "    onShutdown.Invoke()"
+
+        line
+          $"    AotRuntime.invokeWithoutParameter server handlings \"{route}\" cancellationToken (fun () -> server.{name}())"
+      elif Array.isEmpty request.ParamsSafe then
+        line $"  override _.{name}Async(cancellationToken) ="
+
+        line
+          $"    AotRuntime.invokeWithoutParameter server handlings \"{route}\" cancellationToken (fun () -> server.{name}())"
+      else
+        line $"  override _.{name}Async(request, cancellationToken) ="
+
+        line
+          $"    AotRuntime.invokeWithParameter server handlings \"{route}\" request cancellationToken (fun parameter -> server.{name}(parameter))"
+
+    for notification in serverNotifications do
+      let name = normalizeMethod notification.Method
+      let route = escape notification.Method
+
+      if notification.Method = "exit" then
+        line $"  override _.{name}Async(cancellationToken) ="
+        line "    onExit.Invoke()"
+
+        line
+          $"    AotRuntime.notifyWithoutParameter server handlings \"{route}\" cancellationToken (fun () -> server.{name}())"
+      elif Array.isEmpty notification.ParamsSafe then
+        line $"  override _.{name}Async(cancellationToken) ="
+
+        line
+          $"    AotRuntime.notifyWithoutParameter server handlings \"{route}\" cancellationToken (fun () -> server.{name}())"
+      else
+        line $"  override _.{name}Async(request, cancellationToken) ="
+
+        line
+          $"    AotRuntime.notifyWithParameter server handlings \"{route}\" request cancellationToken (fun parameter -> server.{name}(parameter))"
+
+    builder.ToString()
+
+  let generate
+    (metaModel: MetaModel.MetaModel)
+    (contractAssemblyPath: string)
+    (csharpOutputPath: string)
+    (fsharpOutputPath: string)
+    =
+    async {
+      let assembly = Assembly.LoadFrom contractAssemblyPath
+      let csharp = generateCSharp assembly metaModel
+      let fsharp = generateFSharp metaModel
+
+      Directory.CreateDirectory(Path.GetDirectoryName(csharpOutputPath))
+      |> ignore
+
+      Directory.CreateDirectory(Path.GetDirectoryName(fsharpOutputPath))
+      |> ignore
+
+      do! FileWriters.writeIfChanged csharpOutputPath csharp
+      do! FileWriters.writeIfChanged fsharpOutputPath fsharp
+    }

--- a/tools/MetaModelGenerator/GenerateClientServer.fs
+++ b/tools/MetaModelGenerator/GenerateClientServer.fs
@@ -316,6 +316,12 @@ module GenerateClientServer =
         |> Gen.mkOak
         |> fun oak -> CodeFormatter.FormatOakAsync(oak, formatConfig)
 
+      let formattedText =
+        formattedText.Replace(
+          "  type ServerRequestHandling<'server when 'server :> ILspServer> = { Run: 'server -> System.Delegate }",
+          "  type ServerRequestHandling<'server when 'server :> ILspServer> =\n    { Run: 'server -> System.Delegate }\n#if NET10_0\n\n    override _.ToString() = \"ServerRequestHandling\"\n#endif"
+        )
+
       do! FileWriters.writeIfChanged outputPath formattedText
 
     }

--- a/tools/MetaModelGenerator/GenerateTypes.fs
+++ b/tools/MetaModelGenerator/GenerateTypes.fs
@@ -972,3 +972,60 @@ See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17
 
       do! FileWriters.writeIfChanged outputPath formattedText
     }
+
+  /// Generates the net10 protocol contract without Newtonsoft.Json surface area.
+  /// LSP `any` slots use the JsonElement-backed LSPAny wrapper supplied by AotTypes.fs.
+  let generateAotType (parsedMetaModel: MetaModel.MetaModel) outputPath =
+    async {
+      let temporaryPath =
+        outputPath
+        + ".newtonsoft"
+
+      do! generateType parsedMetaModel temporaryPath
+
+      let! generated =
+        System.IO.File.ReadAllTextAsync temporaryPath
+        |> Async.AwaitTask
+
+      let modern =
+        generated
+          .Replace("open Newtonsoft.Json\n", "open System.Text.Json.Serialization\n")
+          .Replace("open Newtonsoft.Json.Linq\n", "")
+          .Replace("JToken", "LSPAny")
+          .Replace("  [<JsonProperty(NullValueHandling = NullValueHandling.Include)>]\n", "")
+          .Replace("[<JsonConverter(typeof<Converters.StringEnumConverter>)>]\n", "")
+          .Replace(
+            "$\"{x.Start.DebuggerDisplay}-{x.End.DebuggerDisplay}\"",
+            "String.Concat(x.Start.DebuggerDisplay, \"-\", x.End.DebuggerDisplay)"
+          )
+          .Replace(
+            "$\"({x.Line},{x.Character})\"",
+            "String.Concat(\"(\", x.Line.ToString(System.Globalization.CultureInfo.CurrentCulture), \",\", x.Character.ToString(System.Globalization.CultureInfo.CurrentCulture), \")\")"
+          )
+          .Replace(
+            "$\"[{defaultArg x.Severity DiagnosticSeverity.Error}] ({x.Range.DebuggerDisplay}) {x.Message} ({Option.map string x.Code |> Option.defaultValue String.Empty})\"",
+            "let code =\n      x.Code\n      |> Option.map (function\n        | U2.C1 value -> value.ToString(System.Globalization.CultureInfo.CurrentCulture)\n        | U2.C2 value -> value)\n      |> Option.defaultValue String.Empty\n\n    String.Concat(\"[\", (defaultArg x.Severity DiagnosticSeverity.Error).ToString(), \"] (\", x.Range.DebuggerDisplay, \") \", x.Message, \" (\", code, \")\")"
+          )
+
+      let addRecordToString (recordMatch: System.Text.RegularExpressions.Match) =
+        let name = recordMatch.Groups.["name"].Value
+
+        String.Concat(recordMatch.Groups.["declaration"].Value, " with\n\n  override _.ToString() = \"", name, "\"")
+
+      let modern =
+        System.Text.RegularExpressions.Regex.Replace(
+          modern,
+          "(?ms)^(?<declaration>type (?<name>[A-Za-z0-9_`]+) = \\{\n.*?^\\})(?: with)?$",
+          System.Text.RegularExpressions.MatchEvaluator addRecordToString
+        )
+
+      let modern =
+        System.Text.RegularExpressions.Regex.Replace(
+          modern,
+          "(?m)^(?<declaration>type (?<name>[A-Za-z0-9_`]+) = \\{.*\\})$",
+          System.Text.RegularExpressions.MatchEvaluator addRecordToString
+        )
+
+      System.IO.File.Delete temporaryPath
+      do! FileWriters.writeIfChanged outputPath modern
+    }

--- a/tools/MetaModelGenerator/GenerateTypes.fs
+++ b/tools/MetaModelGenerator/GenerateTypes.fs
@@ -1007,25 +1007,6 @@ See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17
             "let code =\n      x.Code\n      |> Option.map (function\n        | U2.C1 value -> value.ToString(System.Globalization.CultureInfo.CurrentCulture)\n        | U2.C2 value -> value)\n      |> Option.defaultValue String.Empty\n\n    String.Concat(\"[\", (defaultArg x.Severity DiagnosticSeverity.Error).ToString(), \"] (\", x.Range.DebuggerDisplay, \") \", x.Message, \" (\", code, \")\")"
           )
 
-      let addRecordToString (recordMatch: System.Text.RegularExpressions.Match) =
-        let name = recordMatch.Groups.["name"].Value
-
-        String.Concat(recordMatch.Groups.["declaration"].Value, " with\n\n  override _.ToString() = \"", name, "\"")
-
-      let modern =
-        System.Text.RegularExpressions.Regex.Replace(
-          modern,
-          "(?ms)^(?<declaration>type (?<name>[A-Za-z0-9_`]+) = \\{\n.*?^\\})(?: with)?$",
-          System.Text.RegularExpressions.MatchEvaluator addRecordToString
-        )
-
-      let modern =
-        System.Text.RegularExpressions.Regex.Replace(
-          modern,
-          "(?m)^(?<declaration>type (?<name>[A-Za-z0-9_`]+) = \\{.*\\})$",
-          System.Text.RegularExpressions.MatchEvaluator addRecordToString
-        )
-
       System.IO.File.Delete temporaryPath
       do! FileWriters.writeIfChanged outputPath modern
     }

--- a/tools/MetaModelGenerator/MetaModelGenerator.fsproj
+++ b/tools/MetaModelGenerator/MetaModelGenerator.fsproj
@@ -6,6 +6,8 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="*" />
     <PackageReference Include="Fabulous.AST" Version="[1.2.0]" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="PrimitiveExtensions.fs" />
@@ -13,6 +15,7 @@
     <Compile Include="Common.fs" />
     <Compile Include="GenerateTypes.fs" />
     <Compile Include="GenerateClientServer.fs" />
+    <Compile Include="GenerateAotMetadata.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 </Project>

--- a/tools/MetaModelGenerator/Program.fs
+++ b/tools/MetaModelGenerator/Program.fs
@@ -28,15 +28,43 @@ module Main =
           "The path to metaModel.json. See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#metaModel"
         | OutputFilePath _ -> "The path to the output file. Should end with .fs"
 
+  type AotMetadataArgs =
+    | MetaModelPath of string
+    | ContractAssemblyPath of string
+    | CSharpOutputFilePath of string
+    | FSharpOutputFilePath of string
+
+    interface IArgParserTemplate with
+      member this.Usage =
+        match this with
+        | MetaModelPath _ -> "The path to metaModel.json."
+        | ContractAssemblyPath _ -> "The path to the built netstandard2.0 protocol assembly."
+        | CSharpOutputFilePath _ -> "The generated C# metadata source path."
+        | FSharpOutputFilePath _ -> "The generated F# static target source path."
+
+  type AotTypesArgs =
+    | MetaModelPath of string
+    | OutputFilePath of string
+
+    interface IArgParserTemplate with
+      member this.Usage =
+        match this with
+        | MetaModelPath _ -> "The path to metaModel.json."
+        | OutputFilePath _ -> "The generated modern F# protocol types source path."
+
   type CommandArgs =
     | [<CliPrefix(CliPrefix.None)>] Types of ParseResults<TypeArgs>
     | [<CliPrefix(CliPrefix.None)>] ClientServer of ParseResults<ClientServerArgs>
+    | [<CliPrefix(CliPrefix.None)>] AotTypes of ParseResults<AotTypesArgs>
+    | [<CliPrefix(CliPrefix.None)>] AotMetadata of ParseResults<AotMetadataArgs>
 
     interface IArgParserTemplate with
       member this.Usage =
         match this with
         | Types _ -> "Generates Types from metaModel.json."
         | ClientServer _ -> "Generates Client/Server"
+        | AotTypes _ -> "Generates System.Text.Json-compatible protocol types."
+        | AotMetadata _ -> "Generates Native AOT serialization and RPC metadata."
 
   let readMetaModel metamodelPath =
     async {
@@ -93,6 +121,30 @@ module Main =
         |> Async.RunSynchronously
 
       GenerateClientServer.generateClientServer metaModel OutputFilePath
+      |> Async.RunSynchronously
+
+    | AotTypes r ->
+      let metaModelPath = r.GetResult <@ AotTypesArgs.MetaModelPath @>
+      let outputFilePath = r.GetResult <@ AotTypesArgs.OutputFilePath @>
+
+      let metaModel =
+        readMetaModel metaModelPath
+        |> Async.RunSynchronously
+
+      GenerateTypes.generateAotType metaModel outputFilePath
+      |> Async.RunSynchronously
+
+    | AotMetadata r ->
+      let metaModelPath = r.GetResult <@ AotMetadataArgs.MetaModelPath @>
+      let contractAssemblyPath = r.GetResult <@ AotMetadataArgs.ContractAssemblyPath @>
+      let csharpOutputPath = r.GetResult <@ AotMetadataArgs.CSharpOutputFilePath @>
+      let fsharpOutputPath = r.GetResult <@ AotMetadataArgs.FSharpOutputFilePath @>
+
+      let metaModel =
+        readMetaModel metaModelPath
+        |> Async.RunSynchronously
+
+      GenerateAotMetadata.generate metaModel contractAssemblyPath csharpOutputPath fsharpOutputPath
       |> Async.RunSynchronously
 
     0


### PR DESCRIPTION
## Why this shape: Native AOT requires static metadata, not merely System.Text.Json

This adds a `net10.0` Native AOT path while preserving the existing `netstandard2.0` package and API. The modern asset uses generated JSON metadata, static RPC registration and the existing protocol model/routes; legacy Newtonsoft/JToken and dynamic APIs remain compatibility-only.

### Evidence

- 99/99 net8 and 1/1 net10 tests pass with zero warnings or errors.
- Exact netstandard API compatibility; zero unapproved net10 drift.
- All 72 routes retain their methods, order and static mappings.
- Fresh and locked package restore, audit, pack, warning-free Native AOT publish and native execution pass.
- The package contains both target assets and one implementation-only metadata assembly.

### Trade-offs

- Net10 intentionally omits legacy Newtonsoft/JToken APIs.
- F# reflection-free compilation omits 365 generated structural `ToString` declarations while retaining intentional behaviour.
- Static AOT support adds a generation step and support assembly (rather than hiding reflection behind suppressions), but avoids a custom transport or parallel protocol model.
